### PR TITLE
Relax ffi dependency.

### DIFF
--- a/ethon.gemspec
+++ b/ethon.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = '[none]'
 
-  s.add_dependency('ffi', ['~> 1.3.0'])
+  s.add_dependency('ffi', ['>= 1.3.0'])
   s.add_dependency('mime-types', ['~> 1.18'])
 
   s.files        = Dir.glob("lib/**/*") + %w(CHANGELOG.md Gemfile LICENSE README.md Rakefile)


### PR DESCRIPTION
Could you please relax the ffi dependency? There is already ffi 1.4 and the test suite passes with it just fine.

BTW I am going to package ethon for Fedora and I need to apply this patch, since Fedora 19 already ships ffi 1.4, so it would be cool if it would be upstreamed. Thank you.
