### PR TITLE
Fixes #26: Attach 'select'

### DIFF
--- a/lib/ethon/curl.rb
+++ b/lib/ethon/curl.rb
@@ -35,12 +35,6 @@ module Ethon
       !(RbConfig::CONFIG['host_os'] !~ /mingw|mswin|bccwin/)
     end
 
-    if Curl.windows?
-      ffi_lib 'ws2_32'
-    else
-      ffi_lib ::FFI::Library::LIBC
-    end
-
     require 'ethon/curls/constants'
     require 'ethon/curls/settings'
     require 'ethon/curls/classes'

--- a/lib/ethon/curls/functions.rb
+++ b/lib/ethon/curls/functions.rb
@@ -51,6 +51,12 @@ module Ethon
         base.attach_function :slist_free_all,         :curl_slist_free_all,      [:pointer],                     :void
         base.instance_variable_set(:@blocking, true)
 
+        if Curl.windows?
+            base.ffi_lib 'ws2_32'
+        else
+            base.ffi_lib ::FFI::Library::LIBC
+        end
+
         base.attach_function :select,                                            [:int, Curl::FDSet.ptr, Curl::FDSet.ptr, Curl::FDSet.ptr, Curl::Timeval.ptr], :int
       end
     end


### PR DESCRIPTION
I could only get the ffi_lib calls to perform properly when included in functions.rb, like @brainsucker did in 59e9505. It might not be as pretty, but it works.

**Before:**

``` ruby
irb(main):001:0> require "ethon"
FFI::NotFoundError: Function 'select' not found in [libcurl]
from D:/ruby/lib/ruby/gems/1.9.1/gems/ffi-1.7.0.dev/lib/ffi/library.rb:251:in `attach_function'
from D:/ruby/lib/ruby/gems/1.9.1/gems/ethon-0.5.11/lib/ethon/curls/functions.rb:60:in `extended'
from D:/ruby/lib/ruby/gems/1.9.1/gems/ethon-0.5.11/lib/ethon/curl.rb:47:in `extend'
from D:/ruby/lib/ruby/gems/1.9.1/gems/ethon-0.5.11/lib/ethon/curl.rb:47:in `<module:Curl>'
from D:/ruby/lib/ruby/gems/1.9.1/gems/ethon-0.5.11/lib/ethon/curl.rb:19:in `<module:Ethon>'
from D:/ruby/lib/ruby/gems/1.9.1/gems/ethon-0.5.11/lib/ethon/curl.rb:14:in `<top (required)>'
from D:/ruby/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
from D:/ruby/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
from D:/ruby/lib/ruby/gems/1.9.1/gems/ethon-0.5.11/lib/ethon.rb:8:in `<top (required)>'
from D:/ruby/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:60:in `require'
from D:/ruby/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:60:in `rescue in require'
from D:/ruby/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:35:in `require'
from (irb):1
from D:/ruby/bin/irb:12:in `<main>'
```

**After:**

``` ruby
irb(main):001:0> require "ethon"
=> true
irb(main):002:0> require "typhoeus"
=> true
```
