### PR TITLE
solve "undefined method `each' for nil:NilClass" that appears sometimes

### DIFF
--- a/lib/ethon/easy/response_callbacks.rb
+++ b/lib/ethon/easy/response_callbacks.rb
@@ -39,7 +39,7 @@ module Ethon
       # @example Execute on_completes.
       #   request.complete
       def complete
-        if defined?(@on_complete)
+        if @on_complete
           @on_complete.each{ |callback| callback.call(self) }
         end
       end


### PR DESCRIPTION
defined? returns true even if @on_complete is defined as nil, by changing line 42 as I suggested we ensure that we never enter in the each loop with a nil @on_complete
