### PR TITLE
Fix effective_url test

### DIFF
--- a/spec/ethon/easy/informations_spec.rb
+++ b/spec/ethon/easy/informations_spec.rb
@@ -52,7 +52,7 @@ describe Ethon::Easy::Informations do
 
   describe "#effective_url" do
     it "returns url" do
-      expect(easy.effective_url).to eq("http://localhost:3001")
+      expect(easy.effective_url).to match(/^http:\/\/localhost:3001\/?/)
     end
   end
 


### PR DESCRIPTION
As of curl 7.30.0 (commit https://github.com/bagder/curl/commit/e4b733e3f1a7), a trailing slash is appended to the url if it's missing. This makes the effective_url test pass for all versions of curl.
