### PR TITLE
Fix potential null-pointer dereference in Curls::Infos::get_info_string

### DIFF
--- a/lib/ethon/curls/infos.rb
+++ b/lib/ethon/curls/infos.rb
@@ -105,7 +105,8 @@ module Ethon
       # @return [ String ] The info.
       def get_info_string(option, handle)
         if easy_getinfo(handle, option, string_ptr) == :ok
-          string_ptr.read_pointer.read_string
+          ptr=string_ptr.read_pointer
+          ptr.null? ? nil : ptr.read_string
         end
       end
 


### PR DESCRIPTION
Apparently, CURLE_OK does not mean that a valid string has actually been returned.
