### PR TITLE
Workaround for Typhoeus to persist cookie jar to disk

### DIFF
--- a/lib/ethon/easy/operations.rb
+++ b/lib/ethon/easy/operations.rb
@@ -13,6 +13,15 @@ module Ethon
         @handle ||= FFI::AutoPointer.new(Curl.easy_init, Curl.method(:easy_cleanup))
       end
 
+      # Assign a curl easy handle to this object.
+      #
+      # @example Clear the handle (and perform curl_easy_cleanup)
+      #   easy.handle = nil
+      #
+      def handle=(handle)
+        @handle = handle
+      end
+
       # Perform the easy request.
       #
       # @example Perform the request.

--- a/lib/ethon/multi/stack.rb
+++ b/lib/ethon/multi/stack.rb
@@ -40,6 +40,7 @@ module Ethon
       def delete(easy)
         if easy_handles.delete(easy)
           code = Curl.multi_remove_handle(handle, easy.handle)
+          easy.handle = nil
           raise Errors::MultiRemove.new(code, handle) unless code == :ok
         end
       end


### PR DESCRIPTION
This is an attempt at fixing https://github.com/typhoeus/typhoeus/issues/291 (Cookie jar option is not writing file to disk)

It works in my use case and satisfies libcurl's recommended cleanup sequence (curl_multi_remove_handle, curl_easy_cleanup, then curl_easy_cleanup) though frankly I couldn't figure out why garbage collection is not automatically triggering curl_easy_cleanup without this workaround.
