### PR TITLE
[WIP] Exposing curl_version_info to ruby, supports_asynch_dns? helper

### DIFF
--- a/lib/ethon/curls/classes.rb
+++ b/lib/ethon/curls/classes.rb
@@ -10,6 +10,18 @@ module Ethon
       layout :code, :msg_code, :easy_handle, :pointer, :data, MsgData
     end
 
+    class VersionInfoData < ::FFI::Struct
+      layout :curl_version, :uint8,
+        :version, :string,
+        :version_num, :int,
+        :host, :string,
+        :features, :int,
+        :ssl_version, :string,
+        :ssl_version_num, :long,
+        :libz_version, :string,
+        :protocols, :pointer
+    end
+
     # :nodoc:
     class FDSet < ::FFI::Struct
       if Curl.windows?

--- a/lib/ethon/curls/constants.rb
+++ b/lib/ethon/curls/constants.rb
@@ -39,5 +39,24 @@ module Ethon
 
     # :nodoc:
     MsgCode = enum(:msg_code, msg_codes)
+
+    VERSION_IPV6 = (1<<0)  # IPv6-enabled
+    VERSION_KERBEROS4 = (1<<1)  # kerberos auth is supported
+    VERSION_SSL = (1<<2)  # SSL options are present
+    VERSION_LIBZ = (1<<3)  # libz features are present
+    VERSION_NTLM = (1<<4)  # NTLM auth is supported
+    VERSION_GSSNEGOTIATE = (1<<5) # Negotiate auth supp
+    VERSION_DEBUG = (1<<6)  # built with debug capabilities
+    VERSION_ASYNCHDNS = (1<<7)  # asynchronous dns resolves
+    VERSION_SPNEGO = (1<<8)  # SPNEGO auth is supported
+    VERSION_LARGEFILE = (1<<9)  # supports files bigger than 2GB
+    VERSION_IDN = (1<<10) # International Domain Names support
+    VERSION_SSPI = (1<<11) # SSPI is supported
+    VERSION_CONV = (1<<12) # character conversions supported
+    VERSION_CURLDEBUG = (1<<13) # debug memory tracking supported
+    VERSION_TLSAUTH_SRP = (1<<14) # TLS-SRP auth is supported
+    VERSION_NTLM_WB = (1<<15) # NTLM delegating to winbind helper
+    VERSION_HTTP2 = (1<<16) # HTTP2 support built
+    VERSION_GSSAPI = (1<<17) # GSS-API is supported
   end
 end

--- a/lib/ethon/curls/functions.rb
+++ b/lib/ethon/curls/functions.rb
@@ -44,6 +44,8 @@ module Ethon
         base.attach_function :multi_setopt_off_t,         :curl_multi_setopt,        [:pointer, :multi_option, :int64],    :multi_code
 
         base.attach_function :version,                    :curl_version,             [],                             :string
+        base.attach_function :version_info,               :curl_version_info,        [],                             Curl::VersionInfoData.ptr
+
         base.attach_function :slist_append,               :curl_slist_append,        [:pointer, :string],            :pointer
         base.attach_function :slist_free_all,             :curl_slist_free_all,      [:pointer],                     :void
         base.instance_variable_set(:@blocking, true)

--- a/lib/ethon/easy.rb
+++ b/lib/ethon/easy.rb
@@ -1,4 +1,5 @@
 require 'ethon/easy/informations'
+require 'ethon/easy/features'
 require 'ethon/easy/callbacks'
 require 'ethon/easy/options'
 require 'ethon/easy/header'
@@ -39,6 +40,7 @@ module Ethon
     include Ethon::Easy::Http
     include Ethon::Easy::Operations
     include Ethon::Easy::ResponseCallbacks
+    extend Ethon::Easy::Features
 
     # Returns the curl return code.
     #

--- a/lib/ethon/easy/features.rb
+++ b/lib/ethon/easy/features.rb
@@ -1,0 +1,30 @@
+module Ethon
+  class Easy
+
+    # This module contains class methods for feature checks
+    module Features
+      # Returns true if this curl version supports zlib.
+      #
+      # @example Return wether zlib is supported.
+      #   Ethon::Easy.supports_zlib?
+      #
+      # @return [ Boolean ] True if supported, else false.
+      def supports_zlib?
+        !!(Curl.version_info[:features] & Curl::VERSION_LIBZ)
+      end
+
+      # Returns true if this curl version supports AsynchDNS.
+      #
+      # @example
+      #   Ethon::Easy.supports_asynch_dns?
+      #
+      # @return [ Boolean ] True if supported, else false.
+      def supports_asynch_dns?
+        !!(Curl.version_info[:features] & Curl::VERSION_ASYNCHDNS)
+      end
+
+      alias :supports_timeout_ms? :supports_asynch_dns?
+
+    end
+  end
+end

--- a/lib/ethon/easy/informations.rb
+++ b/lib/ethon/easy/informations.rb
@@ -71,15 +71,27 @@ module Ethon
         eval %Q|def #{name}; Curl.send(:get_info_#{type}, :#{name}, handle); end|
       end
 
-      # Returns this curl version supports zlib.
+      # Returns true if this curl version supports zlib.
       #
       # @example Return wether zlib is supported.
       #   easy.supports_zlib?
       #
       # @return [ Boolean ] True if supported, else false.
       def supports_zlib?
-        !!(Curl.version.match(/zlib/))
+        !!(Curl.version_info[:features] & Curl::VERSION_LIBZ)
       end
+
+      # Returns true if this curl version supports AsynchDNS.
+      #
+      # @example
+      #   easy.supports_asynch_dns?
+      #
+      # @return [ Boolean ] True if supported, else false.
+      def supports_asynch_dns?
+        !!(Curl.version_info[:features] & Curl::VERSION_ASYNCHDNS)
+      end
+
+      alias :supports_timeout_ms? :supports_asynch_dns?
     end
   end
 end

--- a/lib/ethon/easy/informations.rb
+++ b/lib/ethon/easy/informations.rb
@@ -77,21 +77,12 @@ module Ethon
       #   easy.supports_zlib?
       #
       # @return [ Boolean ] True if supported, else false.
+      # @deprecated Please use the static version instead
       def supports_zlib?
-        !!(Curl.version_info[:features] & Curl::VERSION_LIBZ)
+        Kernel.warn("Ethon: Easy#supports_zlib? is deprecated and will be removed, please use Easy#.")
+        Easy.supports_zlib?
       end
 
-      # Returns true if this curl version supports AsynchDNS.
-      #
-      # @example
-      #   easy.supports_asynch_dns?
-      #
-      # @return [ Boolean ] True if supported, else false.
-      def supports_asynch_dns?
-        !!(Curl.version_info[:features] & Curl::VERSION_ASYNCHDNS)
-      end
-
-      alias :supports_timeout_ms? :supports_asynch_dns?
     end
   end
 end

--- a/spec/ethon/easy/features_spec.rb
+++ b/spec/ethon/easy/features_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Ethon::Easy::Informations do
+
+  describe "#supports_asynch_dns?" do
+    it "returns boolean" do
+      expect([true, false].include? Ethon::Easy.supports_asynch_dns?).to be_truthy
+    end
+  end
+
+  describe "#supports_zlib?" do
+    it "returns boolean" do
+      expect([true, false].include? Ethon::Easy.supports_zlib?).to be_truthy
+    end
+  end
+
+  describe "#supports_timeout_ms?" do
+    it "returns boolean" do
+      expect([true, false].include? Ethon::Easy.supports_timeout_ms?).to be_truthy
+    end
+  end
+
+end

--- a/spec/ethon/easy/informations_spec.rb
+++ b/spec/ethon/easy/informations_spec.rb
@@ -82,14 +82,10 @@ describe Ethon::Easy::Informations do
 
   describe "#supports_zlib?" do
     it "returns true" do
+      Kernel.should_receive(:warn) #deprecation warning
       expect(easy.supports_zlib?).to be_truthy
     end
   end
 
-  describe "#supports_asynch_dns?" do
-    it "returns boolean" do
-      expect([true, false].include? easy.supports_asynch_dns?).to be_truthy
-    end
-  end
 
 end

--- a/spec/ethon/easy/informations_spec.rb
+++ b/spec/ethon/easy/informations_spec.rb
@@ -85,4 +85,11 @@ describe Ethon::Easy::Informations do
       expect(easy.supports_zlib?).to be_truthy
     end
   end
+
+  describe "#supports_asynch_dns?" do
+    it "returns boolean" do
+      expect([true, false].include? easy.supports_asynch_dns?).to be_truthy
+    end
+  end
+
 end

--- a/spec/ethon/easy/options_spec.rb
+++ b/spec/ethon/easy/options_spec.rb
@@ -104,9 +104,9 @@ describe Ethon::Easy::Options do
       end
     end
 
-    if Ethon::Curl.version.match("c-ares")
+    if Ethon::Easy.new.supports_timeout_ms?
       context "when timeout_ms" do
-        let(:timeout_ms) { 900 }
+        let(:timeout_ms) { 100 }
 
         context "when request takes longer" do
           let(:url) { "localhost:3001?delay=1" }
@@ -118,7 +118,7 @@ describe Ethon::Easy::Options do
       end
 
       context "when connecttimeout_ms" do
-        let(:connecttimeout_ms) { 1 }
+        let(:connecttimeout_ms) { 100 }
 
         context "when cannot connect" do
           let(:url) { "localhost:3002" }

--- a/spec/ethon/easy/options_spec.rb
+++ b/spec/ethon/easy/options_spec.rb
@@ -104,7 +104,7 @@ describe Ethon::Easy::Options do
       end
     end
 
-    if Ethon::Easy.new.supports_timeout_ms?
+    if Ethon::Easy.supports_timeout_ms?
       context "when timeout_ms" do
         let(:timeout_ms) { 100 }
 

--- a/spec/ethon/easy/options_spec.rb
+++ b/spec/ethon/easy/options_spec.rb
@@ -124,7 +124,8 @@ describe Ethon::Easy::Options do
           let(:url) { "localhost:3002" }
 
           it "times out" do
-            expect(easy.return_code).to eq(:couldnt_connect)
+            # this can either lead to a timeout or couldnt connect depending on which happens first
+            expect([:couldnt_connect, :operation_timedout]).to include(easy.return_code)
           end
         end
       end


### PR DESCRIPTION
This is a first step to improve the timeout handling in typhoeus. It exposes curl_version_info and uses it to provide a supports_timeout_ms? helper. *This still needs verification* The benefit over just checking for c-ares in the version string (in addition to using the proper api to query it) is that it should also work for the threaded resolver and other (future) async resolvers.