### PR TITLE
Added redirect_time to available informations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
     * Set `:fd_array` size to the current MS Windows `FD_SETSIZE` (2048).
         ([Tasos Laskos](https://github.com/zapotek)
 
+* Added `redirect_time` value to available informations and `Easy::Mirror`.
+  ([Adrien Jarthon](https://github.com/jarthod)
+
 ## 0.7.1
 
 * MS Windows determination delegated to `Gem.windows?` for better accuracy.

--- a/lib/ethon/easy/informations.rb
+++ b/lib/ethon/easy/informations.rb
@@ -46,6 +46,12 @@ module Ethon
         # start until the name resolution was completed.
         :namelookup_time => :double,
 
+        # Return the time, in seconds, it took for all redirection steps
+        # include name lookup, connect, pretransfer and transfer before the
+        # final transaction was started. time_redirect shows the complete
+        # execution time for multiple redirections. (Added in 7.12.3)
+        :redirect_time => :double,
+
         # Return the last used effective url.
         :effective_url => :string,
 

--- a/spec/ethon/easy/informations_spec.rb
+++ b/spec/ethon/easy/informations_spec.rb
@@ -50,6 +50,12 @@ describe Ethon::Easy::Informations do
     end
   end
 
+  describe "#redirect_time" do
+    it "returns float" do
+      expect(easy.redirect_time).to be_a(Float)
+    end
+  end
+
   describe "#effective_url" do
     it "returns url" do
       expect(easy.effective_url).to match(/^http:\/\/localhost:3001\/?/)

--- a/spec/ethon/easy/mirror_spec.rb
+++ b/spec/ethon/easy/mirror_spec.rb
@@ -8,7 +8,7 @@ describe Ethon::Easy::Mirror do
     [
       :return_code, :response_code, :response_body, :response_headers,
       :total_time, :starttransfer_time, :appconnect_time,
-      :pretransfer_time, :connect_time, :namelookup_time,
+      :pretransfer_time, :connect_time, :namelookup_time, :redirect_time,
       :effective_url, :primary_ip, :redirect_count, :debug_info
     ].each do |name|
       it "contains #{name}" do


### PR DESCRIPTION
Added `redirect_time` value to available informations and `Easy::Mirror` so it can be used from `typhoeus` (upcoming PR). This will have to be published before the typhoeus PR.