### PR TITLE
Add option to enable Rack-like encoding of array parameters

### DIFF
--- a/lib/ethon/easy/http/actionable.rb
+++ b/lib/ethon/easy/http/actionable.rb
@@ -94,10 +94,6 @@ module Ethon
           @easy = easy
 
           if params.empty?
-            # This is called here to have the side effect of removing
-            # the :params_encoding key from options, to avoid forwarding
-            # it to Curl later. FIXME.
-            params_encoding
             easy.url = url
           else
             set_params(easy)

--- a/lib/ethon/easy/http/actionable.rb
+++ b/lib/ethon/easy/http/actionable.rb
@@ -73,9 +73,9 @@ module Ethon
 
           if params.empty?
             # This is called here to have the side effect of removing
-            # the :array_encoding key from options, to avoid forwarding
+            # the :params_encoding key from options, to avoid forwarding
             # it to Curl later. FIXME.
-            array_encoding
+            params_encoding
             easy.url = url
           else
             set_params(easy)
@@ -92,7 +92,7 @@ module Ethon
         # @param [ Easy ] easy The easy to setup.
         def set_params(easy)
           params.escape = true
-          params.array_encoding = array_encoding
+          params.params_encoding = params_encoding
 
           base_url, base_params = url.split("?")
           base_params += "&" if base_params
@@ -103,10 +103,10 @@ module Ethon
         # :typhoeus, but it can also be set to :rack.
         #
         # @example Get encoding from options
-        #   action.array_encoding
+        #   action.params_encoding
         #
-        def array_encoding
-          @array_encoding ||= options.delete(:array_encoding) || :typhoeus
+        def params_encoding
+          @params_encoding ||= options.delete(:params_encoding) || :typhoeus
         end
 
         # Setup request with form.

--- a/lib/ethon/easy/http/actionable.rb
+++ b/lib/ethon/easy/http/actionable.rb
@@ -92,7 +92,7 @@ module Ethon
         # @param [ Easy ] easy The easy to setup.
         def set_params(easy)
           params.escape = true
-          params.rack_arrays = true if array_encoding == :rack
+          params.array_encoding = array_encoding
 
           base_url, base_params = url.split("?")
           base_params += "&" if base_params

--- a/lib/ethon/easy/http/actionable.rb
+++ b/lib/ethon/easy/http/actionable.rb
@@ -8,6 +8,8 @@ module Ethon
       # for more real actions like GET, HEAD, POST and PUT.
       module Actionable
 
+        QUERY_OPTIONS = [ :params, :body, :params_encoding ]
+
         # Create a new action.
         #
         # @example Create a new action.
@@ -134,7 +136,7 @@ module Ethon
           query_options = {}
           options = options.dup
 
-          [ :params, :body, :params_encoding ].each do |query_option|
+          QUERY_OPTIONS.each do |query_option|
             if options.key?(query_option)
               query_options[query_option] = options.delete(query_option)
             end

--- a/lib/ethon/easy/http/actionable.rb
+++ b/lib/ethon/easy/http/actionable.rb
@@ -70,7 +70,12 @@ module Ethon
         # @param [ easy ] easy the easy to setup.
         def setup(easy)
           @easy = easy
+
           if params.empty?
+            # This is called here to have the side effect of removing
+            # the :array_encoding key from options, to avoid forwarding
+            # it to Curl later. FIXME.
+            array_encoding
             easy.url = url
           else
             set_params(easy)
@@ -87,9 +92,21 @@ module Ethon
         # @param [ Easy ] easy The easy to setup.
         def set_params(easy)
           params.escape = true
+          params.rack_arrays = true if array_encoding == :rack
+
           base_url, base_params = url.split("?")
           base_params += "&" if base_params
           easy.url = "#{base_url}?#{base_params}#{params.to_s}"
+        end
+
+        # Get the requested array encoding. By default it's
+        # :typhoeus, but it can also be set to :rack.
+        #
+        # @example Get encoding from options
+        #   action.array_encoding
+        #
+        def array_encoding
+          @array_encoding ||= options.delete(:array_encoding) || :typhoeus
         end
 
         # Setup request with form.

--- a/lib/ethon/easy/http/postable.rb
+++ b/lib/ethon/easy/http/postable.rb
@@ -14,7 +14,7 @@ module Ethon
         # @param [ Easy ] easy The easy to setup.
         def set_form(easy)
           easy.url ||= url
-          form.array_encoding = array_encoding
+          form.params_encoding = params_encoding
           if form.multipart?
             form.escape = false
             form.materialize

--- a/lib/ethon/easy/http/postable.rb
+++ b/lib/ethon/easy/http/postable.rb
@@ -14,7 +14,7 @@ module Ethon
         # @param [ Easy ] easy The easy to setup.
         def set_form(easy)
           easy.url ||= url
-          form.rack_arrays = true if array_encoding == :rack
+          form.array_encoding = array_encoding
           if form.multipart?
             form.escape = false
             form.materialize

--- a/lib/ethon/easy/http/postable.rb
+++ b/lib/ethon/easy/http/postable.rb
@@ -14,6 +14,7 @@ module Ethon
         # @param [ Easy ] easy The easy to setup.
         def set_form(easy)
           easy.url ||= url
+          form.rack_arrays = true if array_encoding == :rack
           if form.multipart?
             form.escape = false
             form.materialize

--- a/lib/ethon/easy/http/putable.rb
+++ b/lib/ethon/easy/http/putable.rb
@@ -14,7 +14,7 @@ module Ethon
         def set_form(easy)
           easy.upload = true
           form.escape = true
-          form.array_encoding = array_encoding
+          form.params_encoding = params_encoding
           easy.infilesize = form.to_s.bytesize
           easy.set_read_callback(form.to_s)
         end

--- a/lib/ethon/easy/http/putable.rb
+++ b/lib/ethon/easy/http/putable.rb
@@ -14,6 +14,7 @@ module Ethon
         def set_form(easy)
           easy.upload = true
           form.escape = true
+          form.rack_arrays = true if array_encoding == :rack
           easy.infilesize = form.to_s.bytesize
           easy.set_read_callback(form.to_s)
         end

--- a/lib/ethon/easy/http/putable.rb
+++ b/lib/ethon/easy/http/putable.rb
@@ -14,7 +14,7 @@ module Ethon
         def set_form(easy)
           easy.upload = true
           form.escape = true
-          form.rack_arrays = true if array_encoding == :rack
+          form.array_encoding = array_encoding
           easy.infilesize = form.to_s.bytesize
           easy.set_read_callback(form.to_s)
         end

--- a/lib/ethon/easy/queryable.rb
+++ b/lib/ethon/easy/queryable.rb
@@ -8,7 +8,7 @@ module Ethon
       # :nodoc:
       def self.included(base)
         base.send(:attr_accessor, :escape)
-        base.send(:attr_accessor, :rack_arrays)
+        base.send(:attr_accessor, :array_encoding)
       end
 
       # Return wether there are elements in params or not.
@@ -98,7 +98,7 @@ module Ethon
         when Hash
           encode_hash_pairs(h, prefix, pairs)
         when Array
-          if rack_arrays
+          if array_encoding == :rack
             encode_rack_array_pairs(h, prefix, pairs)
           else
             encode_indexed_array_pairs(h, prefix, pairs)

--- a/lib/ethon/easy/queryable.rb
+++ b/lib/ethon/easy/queryable.rb
@@ -8,6 +8,7 @@ module Ethon
       # :nodoc:
       def self.included(base)
         base.send(:attr_accessor, :escape)
+        base.send(:attr_accessor, :rack_arrays)
       end
 
       # Return wether there are elements in params or not.
@@ -95,15 +96,34 @@ module Ethon
       def recursively_generate_pairs(h, prefix, pairs)
         case h
         when Hash
-          h.each_pair do |k,v|
-            key = prefix.nil? ? k : "#{prefix}[#{k}]"
-            pairs_for(v, key, pairs)
-          end
+          encode_hash_pairs(h, prefix, pairs)
         when Array
-          h.each_with_index do |v, i|
-            key = "#{prefix}[#{i}]"
-            pairs_for(v, key, pairs)
+          if rack_arrays
+            encode_rack_array_pairs(h, prefix, pairs)
+          else
+            encode_indexed_array_pairs(h, prefix, pairs)
           end
+        end
+      end
+
+      def encode_hash_pairs(h, prefix, pairs)
+        h.each_pair do |k,v|
+          key = prefix.nil? ? k : "#{prefix}[#{k}]"
+          pairs_for(v, key, pairs)
+        end
+      end
+
+      def encode_indexed_array_pairs(h, prefix, pairs)
+        h.each_with_index do |v, i|
+          key = "#{prefix}[#{i}]"
+          pairs_for(v, key, pairs)
+        end
+      end
+
+      def encode_rack_array_pairs(h, prefix, pairs)
+        h.each do |v|
+          key = "#{prefix}[]"
+          pairs_for(v, key, pairs)
         end
       end
 

--- a/lib/ethon/easy/queryable.rb
+++ b/lib/ethon/easy/queryable.rb
@@ -8,7 +8,7 @@ module Ethon
       # :nodoc:
       def self.included(base)
         base.send(:attr_accessor, :escape)
-        base.send(:attr_accessor, :array_encoding)
+        base.send(:attr_accessor, :params_encoding)
       end
 
       # Return wether there are elements in params or not.
@@ -98,7 +98,7 @@ module Ethon
         when Hash
           encode_hash_pairs(h, prefix, pairs)
         when Array
-          if array_encoding == :rack
+          if params_encoding == :rack
             encode_rack_array_pairs(h, prefix, pairs)
           else
             encode_indexed_array_pairs(h, prefix, pairs)

--- a/lib/ethon/version.rb
+++ b/lib/ethon/version.rb
@@ -1,5 +1,5 @@
 module Ethon
 
   # Ethon version.
-  VERSION = '0.7.4'
+  VERSION = '0.7.3'
 end

--- a/lib/ethon/version.rb
+++ b/lib/ethon/version.rb
@@ -1,5 +1,5 @@
 module Ethon
 
   # Ethon version.
-  VERSION = '0.7.3'
+  VERSION = '0.7.4'
 end

--- a/spec/ethon/easy/http/post_spec.rb
+++ b/spec/ethon/easy/http/post_spec.rb
@@ -50,8 +50,8 @@ describe Ethon::Easy::Http::Post do
           end
         end
 
-        context "when array_encoding is :rack" do
-          let(:options) { {:array_encoding => :rack} }
+        context "when params_encoding is :rack" do
+          let(:options) { {:params_encoding => :rack} }
           it "encodes them without indexes" do
             post.setup(easy)
             expect(easy.url).to eq("#{url}?a%5B%5D=foo&a%5B%5D=bar")
@@ -245,8 +245,8 @@ describe Ethon::Easy::Http::Post do
           end
         end
 
-        context "when array_encoding is :rack" do
-          let(:options) { {:array_encoding => :rack} }
+        context "when params_encoding is :rack" do
+          let(:options) { {:params_encoding => :rack} }
 
           it "sets copypostfields with non-indexed, escaped representation" do
             expect(easy).to receive(:copypostfields=).with('a%5B%5D=foo&a%5B%5D=bar')

--- a/spec/ethon/easy/http/post_spec.rb
+++ b/spec/ethon/easy/http/post_spec.rb
@@ -5,7 +5,8 @@ describe Ethon::Easy::Http::Post do
   let(:url) { "http://localhost:3001/" }
   let(:params) { nil }
   let(:form) { nil }
-  let(:post) { described_class.new(url, {:params => params, :body => form}) }
+  let(:options) { Hash.new }
+  let(:post) { described_class.new(url, options.merge({:params => params, :body => form})) }
 
   describe "#setup" do
     context "when nothing" do
@@ -37,6 +38,25 @@ describe Ethon::Easy::Http::Post do
       it "attaches escaped to url" do
         post.setup(easy)
         expect(easy.url).to eq("#{url}?a=1%26")
+      end
+
+      context "with arrays" do
+        let(:params) { {:a => %w( foo bar )} }
+
+        context "by default" do
+          it "encodes them with indexes" do
+            post.setup(easy)
+            expect(easy.url).to eq("#{url}?a%5B0%5D=foo&a%5B1%5D=bar")
+          end
+        end
+
+        context "when array_encoding is :rack" do
+          let(:options) { {:array_encoding => :rack} }
+          it "encodes them without indexes" do
+            post.setup(easy)
+            expect(easy.url).to eq("#{url}?a%5B%5D=foo&a%5B%5D=bar")
+          end
+        end
       end
 
       it "sets postfieldsize" do
@@ -211,6 +231,26 @@ describe Ethon::Easy::Http::Post do
 
           it "sends binary data" do
             expect(easy.response_body).to include('"body":"\\u0001\\u0000\\u0001"')
+          end
+        end
+      end
+
+      context "when arrays" do
+        let(:form) { {:a => %w( foo bar )} }
+
+        context "by default" do
+          it "sets copypostfields with indexed, escaped representation" do
+            expect(easy).to receive(:copypostfields=).with('a%5B0%5D=foo&a%5B1%5D=bar')
+            post.setup(easy)
+          end
+        end
+
+        context "when array_encoding is :rack" do
+          let(:options) { {:array_encoding => :rack} }
+
+          it "sets copypostfields with non-indexed, escaped representation" do
+            expect(easy).to receive(:copypostfields=).with('a%5B%5D=foo&a%5B%5D=bar')
+            post.setup(easy)
           end
         end
       end

--- a/spec/ethon/easy/http/put_spec.rb
+++ b/spec/ethon/easy/http/put_spec.rb
@@ -5,7 +5,8 @@ describe Ethon::Easy::Http::Put do
   let(:url) { "http://localhost:3001/" }
   let(:params) { nil }
   let(:form) { nil }
-  let(:put) { described_class.new(url, {:params => params, :body => form}) }
+  let(:options) { Hash.new }
+  let(:put) { described_class.new(url, options.merge({:params => params, :body => form})) }
 
   describe "#setup" do
     context "when nothing" do
@@ -39,6 +40,25 @@ describe Ethon::Easy::Http::Put do
       it "attaches escaped to url" do
         put.setup(easy)
         expect(easy.url).to eq("#{url}?a=1%26")
+      end
+
+      context "with arrays" do
+        let(:params) { {:a => %w( foo bar )} }
+
+        context "by default" do
+          it "encodes them with indexes" do
+            put.setup(easy)
+            expect(easy.url).to eq("#{url}?a%5B0%5D=foo&a%5B1%5D=bar")
+          end
+        end
+
+        context "when array_encoding is :rack" do
+          let(:options) { {:array_encoding => :rack} }
+          it "encodes them without indexes" do
+            put.setup(easy)
+            expect(easy.url).to eq("#{url}?a%5B%5D=foo&a%5B%5D=bar")
+          end
+        end
       end
 
       it "sets upload" do
@@ -114,6 +134,29 @@ describe Ethon::Easy::Http::Put do
 
           it "submits file" do
             expect(easy.response_body).to include("injecting")
+          end
+        end
+      end
+
+      context "when arrays" do
+        let(:form) { {:a => %w( foo bar )} }
+
+        before do
+          put.setup(easy)
+          easy.perform
+        end
+
+        context "by default" do
+          it "submits an indexed, escaped representation" do
+            expect(easy.response_body).to include('"body":"a%5B0%5D=foo&a%5B1%5D=bar"')
+          end
+        end
+
+        context "when array_encoding is :rack" do
+          let(:options) { {:array_encoding => :rack} }
+
+          it "submits an non-indexed, escaped representation" do
+            expect(easy.response_body).to include('"body":"a%5B%5D=foo&a%5B%5D=bar"')
           end
         end
       end

--- a/spec/ethon/easy/http/put_spec.rb
+++ b/spec/ethon/easy/http/put_spec.rb
@@ -52,8 +52,8 @@ describe Ethon::Easy::Http::Put do
           end
         end
 
-        context "when array_encoding is :rack" do
-          let(:options) { {:array_encoding => :rack} }
+        context "when params_encoding is :rack" do
+          let(:options) { {:params_encoding => :rack} }
           it "encodes them without indexes" do
             put.setup(easy)
             expect(easy.url).to eq("#{url}?a%5B%5D=foo&a%5B%5D=bar")
@@ -152,8 +152,8 @@ describe Ethon::Easy::Http::Put do
           end
         end
 
-        context "when array_encoding is :rack" do
-          let(:options) { {:array_encoding => :rack} }
+        context "when params_encoding is :rack" do
+          let(:options) { {:params_encoding => :rack} }
 
           it "submits an non-indexed, escaped representation" do
             expect(easy.response_body).to include('"body":"a%5B%5D=foo&a%5B%5D=bar"')

--- a/spec/ethon/easy/queryable_spec.rb
+++ b/spec/ethon/easy/queryable_spec.rb
@@ -114,8 +114,8 @@ describe Ethon::Easy::Queryable do
         end
       end
 
-      context "when rack_arrays is true" do
-        before { params.rack_arrays = true }
+      context "when array_encoding is :rack" do
+        before { params.array_encoding = :rack }
         it "transforms without indexes" do
           expect(pairs).to include([:a, 1])
           expect(pairs).to include(["b[]", 2])

--- a/spec/ethon/easy/queryable_spec.rb
+++ b/spec/ethon/easy/queryable_spec.rb
@@ -106,10 +106,21 @@ describe Ethon::Easy::Queryable do
     context "when params contains an array" do
       let(:hash) { {:a => 1, :b => [2, 3]} }
 
-      it "transforms" do
-        expect(pairs).to include([:a, 1])
-        expect(pairs).to include(["b[0]", 2])
-        expect(pairs).to include(["b[1]", 3])
+      context "by default" do
+        it "transforms" do
+          expect(pairs).to include([:a, 1])
+          expect(pairs).to include(["b[0]", 2])
+          expect(pairs).to include(["b[1]", 3])
+        end
+      end
+
+      context "when rack_arrays is true" do
+        before { params.rack_arrays = true }
+        it "transforms without indexes" do
+          expect(pairs).to include([:a, 1])
+          expect(pairs).to include(["b[]", 2])
+          expect(pairs).to include(["b[]", 3])
+        end
       end
     end
 

--- a/spec/ethon/easy/queryable_spec.rb
+++ b/spec/ethon/easy/queryable_spec.rb
@@ -114,8 +114,8 @@ describe Ethon::Easy::Queryable do
         end
       end
 
-      context "when array_encoding is :rack" do
-        before { params.array_encoding = :rack }
+      context "when params_encoding is :rack" do
+        before { params.params_encoding = :rack }
         it "transforms without indexes" do
           expect(pairs).to include([:a, 1])
           expect(pairs).to include(["b[]", 2])


### PR DESCRIPTION
Rack applications expect

```ruby
foo: ['bar', 'baz']
```

to be encoded as:

```
foo[]=bar&foo[]=baz
```

whilst Ethon by default encodes it as:

```
foo[0]=bar&foo[1]=baz
```

This patch adds an `array_encoding` option to `Ethon::Easy`. If it set to `:rack`, then arrays are encoded the Rack way, both in `params: {}` and in `body: {}`. Any other value retains the current behaviour.

The option can be forwarded directly from `Typhoeus::Request.new`.

This implements typhoeus/typhoeus#424.