### PR TITLE
redo select on EINTR

### DIFF
--- a/lib/ethon/multi/operations.rb
+++ b/lib/ethon/multi/operations.rb
@@ -124,7 +124,10 @@ module Ethon
         else
           @timeval[:sec] = timeout / 1000
           @timeval[:usec] = (timeout * 1000) % 1000000
-          code = Curl.select(max_fd + 1, @fd_read, @fd_write, @fd_excep, @timeval)
+          loop do
+            code = Curl.select(max_fd + 1, @fd_read, @fd_write, @fd_excep, @timeval)
+            break unless code < 0 && ::FFI.errno == Errno::EINTR::Errno
+          end
           raise Errors::Select.new(::FFI.errno) if code < 0
         end
       end


### PR DESCRIPTION
Attempt to resolve typhoeus/ethon issue #31.

Redo the select when it returns EINTR (errno==4), indicating that it has
been interrupted by the exection of a signal handler.  No attempt is
made to set a new timeout since that is non-portable (and straces
indicates some fractional second timeout values being passed). This is
intended to be, at worst, waiting up to twice as long as the timeout
given in the event of a signal, which is argubly better than fully
aborting on receiving a signal that has a signal handler installed.

It makes more sense to do this in ethon than in the calling code because
multiple libcurl interfaces are being used within the set_fds method:
both Curl.multi_fdset and Curl.select, and the reinvocation of select
should have the same fdsets, which wouldn't strictly be guaranteed by
calling the set_fds method again.

However, it may make the most sense to do this in libcurl.  Where the
line should be drawn is kind of hazy. A quick search yielded no libcurl
examples that do anything other than emit the errno value back to the
caller.

Script to reproduce are at https://gist.github.com/thwarted/76a16b2d208ffe2ac223