### PR TITLE
Add global and easy clean up methods 

### DIFF
--- a/lib/ethon/curls/functions.rb
+++ b/lib/ethon/curls/functions.rb
@@ -8,7 +8,8 @@ module Ethon
       # :nodoc:
       def self.extended(base)
         base.attach_function :global_init,                :curl_global_init,         [:long],                        :int
-        base.attach_function :free,                       :curl_free,                [:pointer],                      :void
+        base.attach_function :global_cleanup,             :curl_global_cleanup,      [],                             :void
+        base.attach_function :free,                       :curl_free,                [:pointer],                     :void
 
         base.attach_function :easy_init,                  :curl_easy_init,           [],                             :pointer
         base.attach_function :easy_cleanup,               :curl_easy_cleanup,        [:pointer],                     :void

--- a/lib/ethon/easy/operations.rb
+++ b/lib/ethon/easy/operations.rb
@@ -26,6 +26,16 @@ module Ethon
         @return_code
       end
 
+      # Clean up the easy.
+      #
+      # @example Perform clean up.
+      #   easy.cleanup
+      #
+      # @return the result of the free which is nil
+      def cleanup
+        handle.free
+      end
+
       # Prepare the easy. Options, headers and callbacks
       # were set.
       #

--- a/spec/ethon/curl_spec.rb
+++ b/spec/ethon/curl_spec.rb
@@ -23,5 +23,15 @@ describe Ethon::Curl do
         Ethon::Curl.init
       end
     end
+
+    context "when global_cleanup is called" do
+      before { expect(Ethon::Curl).to receive(:global_cleanup) }
+
+      it "logs" do
+        expect(Ethon.logger).to receive(:debug).twice
+        Ethon::Curl.init
+        Ethon::Curl.cleanup
+      end
+    end
   end
 end

--- a/spec/ethon/easy/operations_spec.rb
+++ b/spec/ethon/easy/operations_spec.rb
@@ -50,6 +50,11 @@ describe Ethon::Easy::Operations do
       easy.perform
     end
 
+    it "calls Curl.easy_cleanup" do
+      FFI::AutoPointer.any_instance.should_receive(:free)
+      easy.cleanup
+    end
+
     it "logs" do
       expect(Ethon.logger).to receive(:debug)
       easy.perform


### PR DESCRIPTION
Due to some forking issues in Passenger it became necessary to clean up some things before Passenger spawned its worker processes.  This exposes the global clean up in libcurl and adds a method to Easy to allow for the immediate release of the ffi autopointer and run the easy cleanup. 