### PR TITLE
Easy::Mirror: Reduced object allocations and method calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 [Full Changelog](https://github.com/typhoeus/ethon/compare/v0.7.4...master)
 
+* `Easy::Mirror`: Reduced object allocations and method calls during info handling.
+  ([Tasos Laskos](https://github.com/zapotek)
+
 ## 0.7.4
 
 [Full Changelog](https://github.com/typhoeus/ethon/compare/v0.7.3...v0.7.4)

--- a/lib/ethon/easy/mirror.rb
+++ b/lib/ethon/easy/mirror.rb
@@ -4,18 +4,14 @@ module Ethon
       attr_reader :options
       alias_method :to_hash, :options
 
-      def self.informations_to_mirror
-        Informations::AVAILABLE_INFORMATIONS.keys +
+      INFORMATIONS_TO_MIRROR = Informations::AVAILABLE_INFORMATIONS.keys +
           [:return_code, :response_headers, :response_body, :debug_info]
-      end
 
-      def self.informations_to_log
-        [:effective_url, :response_code, :return_code, :total_time]
-      end
+      INFORMATIONS_TO_LOG = [:effective_url, :response_code, :return_code, :total_time]
 
       def self.from_easy(easy)
         options = {}
-        informations_to_mirror.each do |info|
+        INFORMATIONS_TO_MIRROR.each do |info|
           options[info] = easy.send(info)
         end
         new(options)
@@ -26,12 +22,12 @@ module Ethon
       end
 
       def log_informations
-        Hash[*self.class.informations_to_log.map do |info|
+        Hash[*INFORMATIONS_TO_LOG.map do |info|
           [info, options[info]]
         end.flatten]
       end
 
-      informations_to_mirror.each do |info|
+      INFORMATIONS_TO_MIRROR.each do |info|
         eval %Q|def #{info}; options[#{info}]; end|
       end
     end

--- a/spec/ethon/easy/mirror_spec.rb
+++ b/spec/ethon/easy/mirror_spec.rb
@@ -4,7 +4,7 @@ describe Ethon::Easy::Mirror do
   let(:options) { nil }
   let(:mirror) { described_class.new(options) }
 
-  describe ".informations_to_mirror" do
+  describe "::INFORMATIONS_TO_LOG" do
     [
       :return_code, :response_code, :response_body, :response_headers,
       :total_time, :starttransfer_time, :appconnect_time,
@@ -12,7 +12,7 @@ describe Ethon::Easy::Mirror do
       :effective_url, :primary_ip, :redirect_count, :debug_info
     ].each do |name|
       it "contains #{name}" do
-        expect(described_class.informations_to_mirror).to include(name)
+        expect(described_class::INFORMATIONS_TO_MIRROR).to include(name)
       end
     end
   end
@@ -33,7 +33,7 @@ describe Ethon::Easy::Mirror do
     end
 
     it "only calls methods that exist" do
-      described_class.informations_to_log.each do |method_name|
+      described_class::INFORMATIONS_TO_LOG.each do |method_name|
         expect(mirror.respond_to? method_name).to eql(true)
       end
     end


### PR DESCRIPTION
Methods that just create static objects cost us the object allocation + method call, better use constants instead.
