### PR TITLE
Added support for optional escaping of params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 [Full Changelog](https://github.com/typhoeus/ethon/compare/v0.7.4...master)
 
+* Support optional escaping of params.
+  ([Tasos Laskos](https://github.com/zapotek)
+
 ## 0.7.4
 
 [Full Changelog](https://github.com/typhoeus/ethon/compare/v0.7.3...v0.7.4)

--- a/lib/ethon/easy.rb
+++ b/lib/ethon/easy.rb
@@ -248,6 +248,7 @@ module Ethon
     #   easy.reset
     def reset
       @url = nil
+      @escape = nil
       @hash = nil
       @on_complete = nil
       @on_headers = nil

--- a/lib/ethon/easy/http/actionable.rb
+++ b/lib/ethon/easy/http/actionable.rb
@@ -93,13 +93,18 @@ module Ethon
         def setup(easy)
           @easy = easy
 
+          # Order is important, @easy will be used to provide access to options
+          # relevant to the following operations (like whether or not to escape
+          # values).
+          easy.set_attributes(options)
+
+          set_form(easy) unless form.empty?
+
           if params.empty?
             easy.url = url
           else
             set_params(easy)
           end
-          set_form(easy) unless form.empty?
-          easy.set_attributes(options)
         end
 
         # Setup request with params.
@@ -109,12 +114,16 @@ module Ethon
         #
         # @param [ Easy ] easy The easy to setup.
         def set_params(easy)
-          params.escape = true
+          params.escape = easy.escape?
           params.params_encoding = params_encoding
 
-          base_url, base_params = url.split("?")
-          base_params += "&" if base_params
-          easy.url = "#{base_url}?#{base_params}#{params.to_s}"
+          base_url, base_params = url.split('?')
+          base_url << '?'
+          base_url << base_params.to_s
+          base_url << '&' if base_params
+          base_url << params.to_s
+
+          easy.url = base_url
         end
 
         # Setup request with form.

--- a/lib/ethon/easy/http/postable.rb
+++ b/lib/ethon/easy/http/postable.rb
@@ -20,7 +20,7 @@ module Ethon
             form.materialize
             easy.httppost = form.first.read_pointer
           else
-            form.escape = true
+            form.escape = easy.escape?
             easy.postfieldsize = form.to_s.bytesize
             easy.copypostfields = form.to_s
           end

--- a/lib/ethon/easy/options.rb
+++ b/lib/ethon/easy/options.rb
@@ -10,7 +10,16 @@ module Ethon
         @url = value
         Curl.set_option(:url, value, handle)
       end
-      
+
+      def escape=( b )
+        @escape = b
+      end
+
+      def escape?
+        return true if @escape
+        @escape.nil? ? true : false
+      end
+
       Curl.easy_options.each do |opt,props|
         eval %Q<
           def #{opt}=(value)

--- a/spec/ethon/easy/http/get_spec.rb
+++ b/spec/ethon/easy/http/get_spec.rb
@@ -5,7 +5,8 @@ describe Ethon::Easy::Http::Get do
   let(:url) { "http://localhost:3001/" }
   let(:params) { nil }
   let(:form) { nil }
-  let(:get) { described_class.new(url, {:params => params, :body => form}) }
+  let(:options) { {} }
+  let(:get) { described_class.new(url, {:params => params, :body => form}.merge(options)) }
 
   describe "#setup" do
     it "sets url" do
@@ -84,6 +85,41 @@ describe Ethon::Easy::Http::Get do
           expect(easy.effective_url).to eq("http://localhost:3001/?a=1%26b%3D2")
         end
       end
+
+      context "with :escape" do
+        let(:params) { {:a => "1&b=2"} }
+
+        context 'missing' do
+          it "escapes values" do
+            expect(easy.url).to eq("#{url}?a=1%26b%3D2")
+          end
+        end
+
+        context 'nil' do
+          let(:options) { {:escape => nil} }
+
+          it "escapes values" do
+            expect(easy.url).to eq("#{url}?a=1%26b%3D2")
+          end
+        end
+
+        context 'true' do
+          let(:options) { {:escape => true} }
+
+          it "escapes values" do
+            expect(easy.url).to eq("#{url}?a=1%26b%3D2")
+          end
+        end
+
+        context 'false' do
+          let(:options) { {:escape => false} }
+
+          it "sends raw values" do
+            expect(easy.url).to eq("#{url}?a=1&b=2")
+          end
+        end
+      end
+
     end
   end
 end

--- a/spec/ethon/easy/http/post_spec.rb
+++ b/spec/ethon/easy/http/post_spec.rb
@@ -59,6 +59,42 @@ describe Ethon::Easy::Http::Post do
         end
       end
 
+      context "with :escape" do
+        context 'missing' do
+          it "escapes values" do
+            post.setup(easy)
+            expect(easy.url).to eq("#{url}?a=1%26")
+          end
+        end
+
+        context 'nil' do
+          let(:options) { {:escape => nil} }
+
+          it "escapes values" do
+            post.setup(easy)
+            expect(easy.url).to eq("#{url}?a=1%26")
+          end
+        end
+
+        context 'true' do
+          let(:options) { {:escape => true} }
+
+          it "escapes values" do
+            post.setup(easy)
+            expect(easy.url).to eq("#{url}?a=1%26")
+          end
+        end
+
+        context 'false' do
+          let(:options) { {:escape => false} }
+
+          it "sends raw values" do
+            post.setup(easy)
+            expect(easy.url).to eq("#{url}?a=1&")
+          end
+        end
+      end
+
       it "sets postfieldsize" do
         expect(easy).to receive(:postfieldsize=).with(0)
         post.setup(easy)

--- a/spec/ethon/easy/options_spec.rb
+++ b/spec/ethon/easy/options_spec.rb
@@ -45,6 +45,35 @@ describe Ethon::Easy::Options do
     end
   end
 
+  describe '#escape?' do
+    context 'by default' do
+      it 'returns true' do
+        expect(easy.escape?).to be_truthy
+      end
+    end
+
+    context 'when #escape=nil' do
+      it 'returns true' do
+        easy.escape = nil
+        expect(easy.escape?).to be_truthy
+      end
+    end
+
+    context 'when #escape=true' do
+      it 'returns true' do
+        easy.escape = true
+        expect(easy.escape?).to be_truthy
+      end
+    end
+
+    context 'when #escape=false' do
+      it 'returns true' do
+        easy.escape = false
+        expect(easy.escape?).to be_falsey
+      end
+    end
+  end
+
   describe "#httppost=" do
     it "raises unless given a FFI::Pointer" do
       expect{ easy.httppost = 1 }.to raise_error(Ethon::Errors::InvalidValue)

--- a/spec/ethon/easy_spec.rb
+++ b/spec/ethon/easy_spec.rb
@@ -64,6 +64,12 @@ describe Ethon::Easy do
       expect(easy.url).to be_nil
     end
 
+    it "resets escape?" do
+      easy.escape = false
+      easy.reset
+      expect(easy.escape?).to be_truthy
+    end
+
     it "resets hash" do
       easy.reset
       expect(easy.instance_variable_get(:@hash)).to be_nil


### PR DESCRIPTION
Sometimes it's necessary to disable the built-in escaping of parameters, whether in URL queries or request bodies.

In my use-case, this is required in order to perform certain [security checks](https://github.com/Arachni/arachni/issues/626).
In addition, I've been able to reduce overhead by caching my own escaping operation as I'm performing thousands of requests with many similarities.

There probably are more use-cases where this can be useful.