### PR TITLE
Mime types columnar

### DIFF
--- a/lib/ethon.rb
+++ b/lib/ethon.rb
@@ -2,8 +2,12 @@ require 'logger'
 require 'ffi'
 require 'thread'
 begin
-  require 'mime/types'
+  require 'mime/types/columnar'
 rescue LoadError
+  begin
+    require 'mime/types'
+  rescue LoadError
+  end
 end
 require 'tempfile'
 

--- a/spec/ethon/easy/queryable_spec.rb
+++ b/spec/ethon/easy/queryable_spec.rb
@@ -162,13 +162,14 @@ describe Ethon::Easy::Queryable do
             let(:file) { Tempfile.new("fubar") }
 
             it "sets mime type to default application/octet-stream" do
-              Object.send(:remove_const, :MIME)
               expect(mime_type).to eq("application/octet-stream")
             end
           end
         end
 
         context "when no MIME" do
+          before { hide_const("MIME") }
+
           it "sets mime type to default application/octet-stream" do
             expect(mime_type).to eq("application/octet-stream")
           end


### PR DESCRIPTION
This PR does two things in relation to issue https://github.com/typhoeus/ethon/issues/109. 

1) Fixes a false positive in the mime types spec (remove_const was in the wrong spec context, and wasn't reset between tests, so I instead use hide_const and put it in the correct spec context)

2) Allows ethon to use mime/types/columnar instead of the default to reduce memory usage. (see https://github.com/mime-types/ruby-mime-types/blob/b83af2c/README.rdoc#columnar-store). Although it was possible to trigger this behavior manually (https://twitter.com/schneems/status/603227060199272448), many people aren't aware of this, and I think it makes sense to default to the columnar store, similar to how the ruby mail gem does (https://github.com/mikel/mail/blob/dc0f89bb33722ec1e6fa404a34055fe6e0189651/lib/mail.rb).

From what I can tell, no special code is required to use the columnar store outside of the require, and in a test rails project that uses ethon, using the gem from this PR results in an automatic reduction of memory use.