### PR TITLE
Various cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,26 @@
-script: "bundle exec rake"
+language: ruby
+cache: bundler
 sudo: false
+
 bundler_args: --without perf
+script: bundle exec rake
+
 rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
-  - 2.0.0
+  - 2.0.0-p648
+  - 2.1.8
+  - 2.2.4
+  - 2.3.0
   - ruby-head
   - ree
-  - jruby-head
   - jruby-18mode
   - jruby-19mode
+  - jruby-head
+  - rbx-2
+
 matrix:
   allow_failures:
+    - rvm: ree
     - rvm: ruby-head
-    - rvm: jruby-head
-    - rvm: rbx-18mode
-    - rvm: rbx-19mode

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "rake"
 group :development, :test do
   gem "rspec", "~> 2.11"
 
-  gem "sinatra", :git => "https://github.com/sinatra/sinatra.git"
+  gem 'sinatra'
   gem "json"
   gem "mime-types", "~> 1.18"
 

--- a/lib/ethon/curls/options.rb
+++ b/lib/ethon/curls/options.rb
@@ -13,7 +13,7 @@ module Ethon
       def set_option(option, value, handle, type = :easy)
         type = type.to_sym unless type.is_a?(Symbol)
         raise NameError, "Ethon::Curls::Options unknown type #{type}." unless respond_to?(OPTION_STRINGS[type])
-        opthash=send(OPTION_STRINGS[type])
+        opthash=send(OPTION_STRINGS[type], nil)
         raise Errors::InvalidOption.new(option) unless opthash.include?(option)
 
         case opthash[option][:type]
@@ -190,14 +190,12 @@ module Ethon
       end
 
       def self.option_type(type)
-        cname="#{type.to_s.upcase}_OPTIONS"
-        c=const_set(cname,{})
-        eval %Q<
-          def #{type.to_s.downcase}_options(rt=nil)
-            return #{cname}.map { |k,v| [k,v[:opt]] } if rt==:enum
-            #{cname}
-          end
-        >
+        cname = FOPTION_STRINGS[type]
+        const_set(cname, {})
+        define_method(OPTION_STRINGS[type]) do |rt|
+          return Ethon::Curls::Options.const_get(cname).map { |k, v| [k, v[:opt]] } if rt == :enum
+          Ethon::Curls::Options.const_get(cname)
+        end
       end
 
       # Curl multi options, refer

--- a/lib/ethon/curls/options.rb
+++ b/lib/ethon/curls/options.rb
@@ -6,6 +6,7 @@ module Ethon
     module Options
 
       OPTION_STRINGS = { :easy => 'easy_options', :multi => 'multi_options' }.freeze
+      FOPTION_STRINGS = { :easy => 'EASY_OPTIONS', :multi => 'MULTI_OPTIONS' }.freeze
       FTYPES = [:long, :string, :ffipointer, :callback, :debug_callback, :off_t]
       FUNCS = Hash[*[:easy, :multi].zip([:easy, :multi].map { |t| Hash[*FTYPES.zip(FTYPES.map { |ft| "#{t}_setopt_#{ft}" }).flatten] }).flatten]
       # Sets appropriate option for easy, depending on value type.
@@ -177,13 +178,14 @@ module Ethon
         else
           raise ArgumentError, "Ethon::Curls::Options #{ftype} #{name} Expected no opts." unless opts.nil?
         end
-
-        opthash=const_get("#{ftype.to_s.upcase}_OPTIONS")
-        opthash[name]={:type=>type, :opt=>OPTION_TYPE_BASE[OPTION_TYPE_MAP[type]]+num, :opts=>opts}
+        opthash=const_get(FOPTION_STRINGS[ftype])
+        opthash[name] = { :type => type,
+                          :opt => OPTION_TYPE_BASE[OPTION_TYPE_MAP[type]] + num,
+                          :opts => opts }
       end
 
       def self.option_alias(ftype,name,*aliases)
-        opthash=const_get("#{ftype.to_s.upcase}_OPTIONS")
+        opthash=const_get(FOPTION_STRINGS[ftype])
         aliases.each { |a| opthash[a]=opthash[name] }
       end
 

--- a/lib/ethon/easy/operations.rb
+++ b/lib/ethon/easy/operations.rb
@@ -21,7 +21,9 @@ module Ethon
       # @return [ Integer ] The return code.
       def perform
         @return_code = Curl.easy_perform(handle)
-        Ethon.logger.debug { "ETHON: performed #{self.log_inspect}" }
+        if Ethon.logger.level.zero?
+          Ethon.logger.debug { "ETHON: performed #{log_inspect}" }
+        end
         complete
         @return_code
       end

--- a/lib/ethon/easy/options.rb
+++ b/lib/ethon/easy/options.rb
@@ -20,7 +20,7 @@ module Ethon
         @escape.nil? ? true : false
       end
 
-      Curl.easy_options.each do |opt, props|
+      Curl.easy_options(nil).each do |opt, props|
         method_name = "#{opt}=".freeze
         unless method_defined? method_name
           define_method(method_name) do |value|

--- a/spec/ethon/easy/operations_spec.rb
+++ b/spec/ethon/easy/operations_spec.rb
@@ -25,6 +25,7 @@ describe Ethon::Easy::Operations do
     let(:password) { nil }
 
     before do
+      Ethon.logger.level = Logger::DEBUG
       easy.url = url
       easy.timeout = timeout
       easy.connecttimeout = connect_timeout

--- a/spec/support/server.rb
+++ b/spec/support/server.rb
@@ -4,7 +4,7 @@ require 'zlib'
 require 'sinatra/base'
 
 TESTSERVER = Sinatra.new do
-  set :logging, false
+  set :logging, nil
 
   fail_count = 0
 


### PR DESCRIPTION
Basically reducing of string allocations all over the place for the default/easy case.
[Speed is slightly increased](https://gist.github.com/ojab/8cc143e1be7dc8b0c005), memory usage is slightly reduced: simple testcase
```ruby
#!/usr/bin/env ruby
require 'ethon'
require 'memory_profiler'

URL = 'http://localhost:4567/none'.freeze

report = MemoryProfiler.report do
  e_orig = Ethon::Easy.new(url: URL)
  10_000.times do
    e = e_orig.dup
    e.perform
  end
end
report.pretty_print
```
reports before:
```
Total allocated: 13629088 bytes (150094 objects)
Total retained:  1050264 bytes (12 objects)

allocated memory by gem
-----------------------------------
   8308112  ethon/lib
   4120080  ffi-1.9.10
   1200352  other
       544  ruby-2.3.0/lib
```
and after
```
Total allocated: 11787601 bytes (130058 objects)
Total retained:  1050184 bytes (10 objects)

allocated memory by gem
-----------------------------------
   6466625  ethon/lib
   4120080  ffi-1.9.10
   1200352  other
       544  ruby-2.3.0/lib
```
This is the worst case, with many options & `Ethon::Easy.new` savings would be higher.