### PR TITLE
Expose curl_easy_duphandle as Ethon::Easy.dup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,26 @@
-script: "bundle exec rake"
+language: ruby
+cache: bundler
 sudo: false
+
 bundler_args: --without perf
+script: bundle exec rake
+
 rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
-  - 2.0.0
+  - 2.0.0-p648
+  - 2.1.8
+  - 2.2.4
+  - 2.3.0
   - ruby-head
   - ree
-  - jruby-head
   - jruby-18mode
   - jruby-19mode
+  - jruby-head
+  - rbx-2
+
 matrix:
   allow_failures:
+    - rvm: ree
     - rvm: ruby-head
-    - rvm: jruby-head
-    - rvm: rbx-18mode
-    - rvm: rbx-19mode

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "rake"
 group :development, :test do
   gem "rspec", "~> 2.11"
 
-  gem "sinatra", :git => "https://github.com/sinatra/sinatra.git"
+  gem 'sinatra'
   gem "json"
   gem "mime-types", "~> 1.18"
 

--- a/lib/ethon/curls/functions.rb
+++ b/lib/ethon/curls/functions.rb
@@ -25,6 +25,7 @@ module Ethon
         base.attach_function :easy_strerror,              :curl_easy_strerror,       [:easy_code],                   :string
         base.attach_function :easy_escape,                :curl_easy_escape,         [:pointer, :pointer, :int],     :pointer
         base.attach_function :easy_reset,                 :curl_easy_reset,          [:pointer],                     :void
+        base.attach_function :easy_duphandle,             :curl_easy_duphandle,      [:pointer],                     :pointer
 
         base.attach_function :formadd,                    :curl_formadd,             [:pointer, :pointer, :varargs], :int
         base.attach_function :formfree,                   :curl_formfree,            [:pointer],                     :void

--- a/lib/ethon/easy.rb
+++ b/lib/ethon/easy.rb
@@ -259,6 +259,17 @@ module Ethon
       set_callbacks
     end
 
+    # Clones libcurl session handle. This means that all options that is set in
+    #   the current handle will be set on duplicated handle.
+    def dup
+      e = super
+      e.instance_variable_set(:@body_write_callback, nil)
+      e.instance_variable_set(:@header_write_callback, nil)
+      e.instance_variable_set(:@debug_callback, nil)
+      e.set_callbacks
+      e.handle = Curl.easy_duphandle(handle)
+      e
+    end
     # Url escapes the value.
     #
     # @example Url escape.

--- a/lib/ethon/easy/operations.rb
+++ b/lib/ethon/easy/operations.rb
@@ -13,6 +13,12 @@ module Ethon
         @handle ||= FFI::AutoPointer.new(Curl.easy_init, Curl.method(:easy_cleanup))
       end
 
+      # Sets a pointer to the curl easy handle.
+      # @param [ ::FFI::Pointer ] Easy handle that will be assigned.
+      def handle=(h)
+        @handle = h
+      end
+
       # Perform the easy request.
       #
       # @example Perform the request.

--- a/spec/ethon/easy_spec.rb
+++ b/spec/ethon/easy_spec.rb
@@ -99,6 +99,61 @@ describe Ethon::Easy do
     end
   end
 
+  describe "#dup" do
+    let(:e) { easy.dup }
+    before do
+      easy.url = "http://localhost:3001/"
+      easy.on_complete { p 1 }
+      easy.on_headers { p 1 }
+      easy.response_body = "test_body"
+      easy.response_headers = "test_headers"
+    end
+
+    it "sets a new handle" do
+      expect(e.handle).not_to eq(easy.handle)
+    end
+
+    it "preserves url" do
+      expect(e.url).to eq(easy.url)
+    end
+
+    it "preserves on_complete callback" do
+      expect(e.on_complete).to be(easy.on_complete)
+    end
+
+    it "preserves on_headers callback" do
+      expect(e.on_headers).to be(easy.on_headers)
+    end
+
+    it "resets response_body" do
+      expect(e.response_body).to be_empty
+    end
+
+    it "resets response_headers" do
+      expect(e.response_headers).to be_empty
+    end
+
+    it "sets response_body for duplicated Easy" do
+      e.perform
+      expect(e.response_body).not_to be_empty
+    end
+
+    it "sets response_headers for duplicated Easy" do
+      e.perform
+      expect(e.response_headers).not_to be_empty
+    end
+
+    it "preserves response_body for original Easy" do
+      e.perform
+      expect(easy.response_body).to eq('test_body')
+    end
+
+    it "preserves response_headers for original Easy" do
+      e.perform
+      expect(easy.response_headers).to eq('test_headers')
+    end
+  end
+
   describe "#mirror" do
     it "returns a Mirror" do
       expect(easy.mirror).to be_a(Ethon::Easy::Mirror)

--- a/spec/support/server.rb
+++ b/spec/support/server.rb
@@ -4,7 +4,7 @@ require 'zlib'
 require 'sinatra/base'
 
 TESTSERVER = Sinatra.new do
-  set :logging, false
+  set :logging, nil
 
   fail_count = 0
 


### PR DESCRIPTION
Handy if multiple similar requests should be done, i. e.:
```ruby
easy = Ethon::Easy.new(timeout: 5, …)
[url1, url2, url3].each do |url|
  e = easy.dup
  e.url = url
  e.perform
end
```
saves a bunch of allocations/memory. This can be used even if block with e.perform is executed in multiple threads simultaneously (reusing of `easy` fails in this case).