### PR TITLE
allow passing int values to :enum or :bitmask opts

### DIFF
--- a/lib/ethon/curls/options.rb
+++ b/lib/ethon/curls/options.rb
@@ -41,8 +41,9 @@ module Ethon
             opthash[option][:opts][value]
           when String
             opthash[option][:opts][value.to_sym]
-          end
-          value = value.to_i
+          else
+            value
+          end.to_i
         when :bitmask
           return if value.nil?
           func=:long
@@ -51,8 +52,9 @@ module Ethon
             opthash[option][:opts][value]
           when Array
             value.inject(0) { |res,v| res|opthash[option][:opts][v] }
-          end
-          value = value.to_i
+          else
+            value
+          end.to_i
         when :string
           func=:string
           value=value.to_s unless value.nil?


### PR DESCRIPTION
Discovered this while adding https://github.com/typhoeus/ethon/pull/120

The current functionality will just result in nil.to_i (0) being blindly passed through. If the change here isn't an appropriate solution, maybe an error should be raised instead?