### PR TITLE
We actually want to reset callbacks for duplicated handle, not original

### DIFF
--- a/lib/ethon/easy.rb
+++ b/lib/ethon/easy.rb
@@ -263,11 +263,11 @@ module Ethon
     #   the current handle will be set on duplicated handle.
     def dup
       e = super
+      e.handle = Curl.easy_duphandle(handle)
       e.instance_variable_set(:@body_write_callback, nil)
       e.instance_variable_set(:@header_write_callback, nil)
       e.instance_variable_set(:@debug_callback, nil)
       e.set_callbacks
-      e.handle = Curl.easy_duphandle(handle)
       e
     end
     # Url escapes the value.

--- a/spec/ethon/easy_spec.rb
+++ b/spec/ethon/easy_spec.rb
@@ -100,14 +100,16 @@ describe Ethon::Easy do
   end
 
   describe "#dup" do
-    let(:e) { easy.dup }
-    before do
+    let!(:easy) do
+      easy = Ethon::Easy.new
       easy.url = "http://localhost:3001/"
-      easy.on_complete { p 1 }
-      easy.on_headers { p 1 }
-      easy.response_body = "test_body"
-      easy.response_headers = "test_headers"
+      easy.on_complete { 'on_complete' }
+      easy.on_headers { 'on_headers' }
+      easy.response_body = 'test_body'
+      easy.response_headers = 'test_headers'
+      easy
     end
+    let!(:e) { easy.dup }
 
     it "sets a new handle" do
       expect(e.handle).not_to eq(easy.handle)
@@ -123,6 +125,26 @@ describe Ethon::Easy do
 
     it "preserves on_headers callback" do
       expect(e.on_headers).to be(easy.on_headers)
+    end
+
+    it 'preserves body_write_callback of original handle' do
+      expect { easy.perform }.to change { easy.response_body }
+      expect { easy.perform }.not_to change { e.response_body }
+    end
+
+    it 'sets new body_write_callback of duplicated handle' do
+      expect { e.perform }.to change { e.response_body }
+      expect { e.perform }.not_to change { easy.response_body }
+    end
+
+    it 'preserves headers_write_callback of original handle' do
+      expect { easy.perform }.to change { easy.response_headers }
+      expect { easy.perform }.not_to change { e.response_headers }
+    end
+
+    it 'sets new headers_write_callback of duplicated handle' do
+      expect { e.perform }.to change { e.response_headers }
+      expect { e.perform }.not_to change { easy.response_headers }
     end
 
     it "resets response_body" do


### PR DESCRIPTION
There is an error in my .dup implementation, now it's fixed.