### PR TITLE
Update Rake and RSpec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,11 @@
 source "https://rubygems.org"
 gemspec
 
-gem "rake"
+if Gem.ruby_version < Gem::Version.new("1.9.3")
+  gem "rake", "< 11"
+else
+  gem "rake"
+end
 
 group :development, :test do
   gem "rspec", "~> 2.11"

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ else
 end
 
 group :development, :test do
-  gem "rspec", "~> 2.11"
+  gem "rspec", "~> 3.4"
 
   gem "sinatra"
   gem "json"

--- a/Gemfile
+++ b/Gemfile
@@ -6,13 +6,13 @@ gem "rake"
 group :development, :test do
   gem "rspec", "~> 2.11"
 
-  gem 'sinatra'
+  gem "sinatra"
   gem "json"
   gem "mime-types", "~> 1.18"
 
   unless ENV["CI"]
     gem "guard-rspec", "~> 0.7"
-    gem 'rb-fsevent', '~> 0.9.1'
+    gem "rb-fsevent", "~> 0.9.1"
   end
 end
 

--- a/spec/ethon/easy/informations_spec.rb
+++ b/spec/ethon/easy/informations_spec.rb
@@ -88,7 +88,7 @@ describe Ethon::Easy::Informations do
 
   describe "#supports_zlib?" do
     it "returns true" do
-      Kernel.should_receive(:warn) #deprecation warning
+      expect(Kernel).to receive(:warn)
       expect(easy.supports_zlib?).to be_truthy
     end
   end

--- a/spec/ethon/easy/operations_spec.rb
+++ b/spec/ethon/easy/operations_spec.rb
@@ -52,7 +52,7 @@ describe Ethon::Easy::Operations do
     end
 
     it "calls Curl.easy_cleanup" do
-      FFI::AutoPointer.any_instance.should_receive(:free)
+      expect_any_instance_of(FFI::AutoPointer).to receive(:free)
       easy.cleanup
     end
 


### PR DESCRIPTION
1. Correct Rake dependency for older Rubies
2. RSpec upgraded to 3.4, deprecations resolved

Perhaps jruby-head tests should go to allowed failures.