### PR TITLE
Add unix socket path option.

### DIFF
--- a/lib/ethon/curls/options.rb
+++ b/lib/ethon/curls/options.rb
@@ -408,6 +408,8 @@ module Ethon
       option :easy, :resolve, :curl_slist, 203
       option :easy, :dns_servers, :string, 211
       option :easy, :accepttimeout_ms, :int, 212
+      option :easy, :unix_socket_path, :string, 231
+      option_alias :easy, :unix_socket_path, :unix_socket
       ## SSL and SECURITY OPTIONS
       option :easy, :sslcert, :string, 25
       option :easy, :sslcerttype, :string, 86


### PR DESCRIPTION
This should provide access to curl's option [CURLOPT_UNIX_SOCKET_PATH](https://curl.haxx.se/libcurl/c/CURLOPT_UNIX_SOCKET_PATH.html)