### PR TITLE
Add support for sending empty header values

### DIFF
--- a/lib/ethon/easy/header.rb
+++ b/lib/ethon/easy/header.rb
@@ -4,6 +4,8 @@ module Ethon
     #
     # @api private
     module Header
+      EMPTY_STRING_VALUE = "".freeze
+
       # Return headers, return empty hash if none.
       #
       # @example Return the headers.
@@ -53,7 +55,11 @@ module Ethon
       #
       # @return [ String ] The composed header.
       def compose_header(key, value)
-        Util.escape_zero_byte("#{key}: #{value}")
+        if(value == EMPTY_STRING_VALUE)
+          Util.escape_zero_byte("#{key};")
+        else
+          Util.escape_zero_byte("#{key}: #{value}")
+        end
       end
     end
   end

--- a/spec/ethon/easy/header_spec.rb
+++ b/spec/ethon/easy/header_spec.rb
@@ -46,6 +46,36 @@ describe Ethon::Easy::Header do
           expect(easy.response_body).to include('"HTTP_USER_AGENT":"Ethon"')
         end
       end
+
+      context "when header value is empty string" do
+        let(:headers) { { 'User-Agent' => "" } }
+
+        if(Ethon::Curl.version_info[:version] >= "7.23.0")
+          it "sends header with empty value" do
+            expect(easy.response_body).to include('"HTTP_USER_AGENT":""')
+          end
+        else
+          it "does not send header (curl < 7.23.0 does not support empty values)" do
+            expect(easy.response_body).to_not include('"HTTP_USER_AGENT"')
+          end
+        end
+      end
+
+      context "when header value is nil" do
+        let(:headers) { { 'User-Agent' => nil } }
+
+        it "does not send header" do
+          expect(easy.response_body).to_not include('"HTTP_USER_AGENT"')
+        end
+      end
+
+      context "when header value is integer" do
+        let(:headers) { { 'User-Agent' => 0 } }
+
+        it "sends as string" do
+          expect(easy.response_body).to include('"HTTP_USER_AGENT":"0"')
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Currently, there's not a super-easy way to pass a header with an empty value (e.g., `X-Foo: `) in Typhoeus or Ethon. If an empty string is passed in as the header value, then currently the header is omitted from the request altogether. This is due to how curl historically treated empty values (see [https://curl.haxx.se/mail/lib-2010-08/0174.html](https://curl.haxx.se/mail/lib-2010-08/0174.html)). Curl 7.23.0 (released November 2011) added a more standard way to pass empty values, but it requires special syntax of using a semicolon terminator.

This changes Ethon's behavior, so that when an empty string is passed as the value of a header, it gets sent by curl as an empty HTTP header, rather than omitting the header. A nil value will still omit the header. This seems like a more intuitive approach to me, but this does make this a backwards incompatible change if you were relying on the previous empty string behavior. So if that seems problematic, let me know if you have any other ideas on how this should be handled, or if you don't think Ethon should handle this at all.

A few implementation notes:

- This requires curl 7.23.0 or higher, where the ability to send empty header values (via a semicolon terminator) was added. If using an older version of curl without this support, then curl's previous behavior of omitting empty headers when an empty string is used remains the same. While this doesn't necessarily seem ideal (since Ethon's behavior will differ depending on the version of curl you have), I'm not sure of the best alternative.
- Based on some micro-benchmarks, detecting empty strings by using the `EMPTY_STRING_VALUE` constant seems like the fastest approach (while `.empty?` is marginally faster it becomes slower once you account for checking whether or not the value is a String).
- The behavior hasn't changed if the value is any other object type, like numbers, but I added a test when passing a number just as a sanity check.