### PR TITLE
Easy::Operations#handle: Thread-safe cleanup

### DIFF
--- a/lib/ethon/easy/operations.rb
+++ b/lib/ethon/easy/operations.rb
@@ -3,6 +3,20 @@ module Ethon
     # This module contains the logic to prepare and perform
     # an easy.
     module Operations
+      
+      class PointerHelper
+        class<<self
+          def synchronize( &block )
+            (@mutex ||= Mutex.new).synchronize( &block )
+          end
+
+          def release( pointer )
+            synchronize { Curl.easy_cleanup pointer }
+          end
+        end
+        synchronize{}
+      end
+
       # Returns a pointer to the curl easy handle.
       #
       # @example Return the handle.
@@ -10,7 +24,7 @@ module Ethon
       #
       # @return [ FFI::Pointer ] A pointer to the curl easy handle.
       def handle
-        @handle ||= FFI::AutoPointer.new(Curl.easy_init, Curl.method(:easy_cleanup))
+        @handle ||= FFI::AutoPointer.new(Curl.easy_init, PointerHelper.method(:release) )
       end
 
       # Sets a pointer to the curl easy handle.


### PR DESCRIPTION
This change fixes intermittent segfaults.
Unfortunately I don't have an easily reproducible test-case but this change seems to 
fix segfaults for a live system.