### PR TITLE
Changes for Ethon to allow multipart-form-data forcing 

### DIFF
--- a/lib/ethon/easy/form.rb
+++ b/lib/ethon/easy/form.rb
@@ -21,9 +21,11 @@ module Ethon
       # @param [ Hash ] params The parameter with which to initialize the form.
       #
       # @return [ Form ] A new Form.
-      def initialize(easy, params)
+      def initialize(easy, params, multipart = nil)
         @easy = easy
         @params = params || {}
+
+        @multipart = multipart
       end
 
       # Return a pointer to the first form element in libcurl.
@@ -47,13 +49,18 @@ module Ethon
       end
 
       # Return if form is multipart. The form is multipart
-      # when it contains a file.
+      # when it contains a file or multipart option is set on the form during creation.
       #
       # @example Return if form is multipart.
       #   form.multipart?
       #
       # @return [ Boolean ] True if form is multipart, else false.
       def multipart?
+
+        if @multipart
+          return true
+        end
+
         query_pairs.any?{|pair| pair.respond_to?(:last) && pair.last.is_a?(Array)}
       end
 

--- a/lib/ethon/easy/form.rb
+++ b/lib/ethon/easy/form.rb
@@ -55,11 +55,7 @@ module Ethon
       #
       # @return [ Boolean ] True if form is multipart, else false.
       def multipart?
-
-        if @multipart
-          return true
-        end
-
+        return true if @multipart
         query_pairs.any?{|pair| pair.respond_to?(:last) && pair.last.is_a?(Array)}
       end
 

--- a/lib/ethon/easy/form.rb
+++ b/lib/ethon/easy/form.rb
@@ -24,7 +24,6 @@ module Ethon
       def initialize(easy, params, multipart = nil)
         @easy = easy
         @params = params || {}
-
         @multipart = multipart
       end
 

--- a/lib/ethon/easy/http/actionable.rb
+++ b/lib/ethon/easy/http/actionable.rb
@@ -71,7 +71,7 @@ module Ethon
         #
         # @return [ Form ] The form.
         def form
-          @form ||= Form.new(@easy, query_options.fetch(:body, nil))
+          @form ||= Form.new(@easy, query_options.fetch(:body, nil), options.fetch(:multipart, nil))
         end
 
         # Get the requested array encoding. By default it's

--- a/lib/ethon/easy/options.rb
+++ b/lib/ethon/easy/options.rb
@@ -25,8 +25,7 @@ module Ethon
       end
 
       def multipart?
-        return false if !defined?(@multipart) || @multipart.nil?
-        @multipart
+        !!@multipart
       end
 
       Curl.easy_options(nil).each do |opt, props|

--- a/lib/ethon/easy/options.rb
+++ b/lib/ethon/easy/options.rb
@@ -20,6 +20,15 @@ module Ethon
         @escape
       end
 
+      def multipart=(b)
+        @multipart = b
+      end
+
+      def multipart?
+        return false if !defined?(@multipart) || @multipart.nil?
+        @multipart
+      end
+
       Curl.easy_options(nil).each do |opt, props|
         method_name = "#{opt}=".freeze
         unless method_defined? method_name

--- a/spec/ethon/easy/form_spec.rb
+++ b/spec/ethon/easy/form_spec.rb
@@ -41,6 +41,15 @@ describe Ethon::Easy::Form do
         expect(form.multipart?).to be_truthy
       end
     end
+
+    context "when options contains multipart=true" do
+      before { form.instance_variable_set(:@multipart, true) }
+      let(:pairs) { [['a', '1'], ['b', '2']] }
+
+      it "returns true" do
+        expect(form.multipart?).to be_truthy
+      end
+    end
   end
 
   describe "#materialize" do

--- a/spec/ethon/easy/options_spec.rb
+++ b/spec/ethon/easy/options_spec.rb
@@ -74,6 +74,35 @@ describe Ethon::Easy::Options do
     end
   end
 
+  describe '#multipart?' do
+    context 'by default' do
+      it 'returns false' do
+        expect(easy.multipart?).to be_falsey
+      end
+    end
+
+    context 'when #multipart=nil' do
+      it 'returns false' do
+        easy.multipart = nil
+        expect(easy.multipart?).to be_falsey
+      end
+    end
+
+    context 'when #multipart=true' do
+      it 'returns true' do
+        easy.multipart = true
+        expect(easy.multipart?).to be_truthy
+      end
+    end
+
+    context 'when #multipart=false' do
+      it 'returns false' do
+        easy.multipart = false
+        expect(easy.multipart?).to be_falsey
+      end
+    end
+  end
+  
   describe "#httppost=" do
     it "raises unless given a FFI::Pointer" do
       expect{ easy.httppost = 1 }.to raise_error(Ethon::Errors::InvalidValue)

--- a/spec/ethon/easy/options_spec.rb
+++ b/spec/ethon/easy/options_spec.rb
@@ -102,7 +102,7 @@ describe Ethon::Easy::Options do
       end
     end
   end
-  
+
   describe "#httppost=" do
     it "raises unless given a FFI::Pointer" do
       expect{ easy.httppost = 1 }.to raise_error(Ethon::Errors::InvalidValue)


### PR DESCRIPTION
When using Typhoeus we noticed we weren't able to force multipart-form-data for form submission if no file is present (it automatically does it if files are present). However there are services out there (not just HTTP file uploads) that handle their forms in multipart-form-data format for variables even if a file isn't submitted, so forcing is sometimes necessary.

This simple PR allows us to submit forms to those services by forcing multipart-form-data generation even if no file is present. It's designed as an option you include in the Request.new() call in Typhoeus, but the work is done inside of Ethon because all the action happens there. Changes were kept to a minimum possible to achieve this feature. No changes were required in Typhoeus for this to function.

**An example request creation:**

```ruby
    req = Typhoeus::Request.new('http://localhost:8081/',
                                method: :post,
                                body: { test: 'test', test2: 'test2' },
                                headers: { 'X-Test' => 'None' },
                                params: 'foo=bar',
                                followlocation: :redirects,
                                multipart: true );

    req.run
```

***Resulting request looks like:***

POST /?foo=bar HTTP/1.1
Host: localhost:8081
Accept: */*
User-Agent: Typhoeus - https://github.com/typhoeus/typhoeus
X-Test: None
Content-Length: 242
Content-Type: multipart/form-data; boundary=------------------------e50e2a4b528e46bd

--------------------------e50e2a4b528e46bd
Content-Disposition: form-data; name=“test”

test
--------------------------e50e2a4b528e46bd
Content-Disposition: form-data; name=“test2"

test2
--------------------------e50e2a4b528e46bd--