### PR TITLE
Add params_encoding :none

### DIFF
--- a/lib/ethon/easy/queryable.rb
+++ b/lib/ethon/easy/queryable.rb
@@ -102,6 +102,8 @@ module Ethon
             encode_rack_array_pairs(h, prefix, pairs)
           elsif params_encoding == :multi
             encode_multi_array_pairs(h, prefix, pairs)
+          elsif params_encoding == :none
+            pairs << [prefix, h]
           else
             encode_indexed_array_pairs(h, prefix, pairs)
           end
@@ -128,7 +130,7 @@ module Ethon
           pairs_for(v, key, pairs)
         end
       end
-      
+
     def encode_multi_array_pairs(h, prefix, pairs)
       h.each_with_index do |v, i|
         key = prefix

--- a/spec/ethon/easy/queryable_spec.rb
+++ b/spec/ethon/easy/queryable_spec.rb
@@ -122,6 +122,14 @@ describe Ethon::Easy::Queryable do
           expect(pairs).to include(["b[]", 3])
         end
       end
+
+      context "when params_encoding is :none" do
+        before { params.params_encoding = :none }
+        it "does no transformation" do
+          expect(pairs).to include([:a, 1])
+          expect(pairs).to include([:b, [2, 3]])
+        end
+      end
     end
 
     context "when params contains something nested in an array" do


### PR DESCRIPTION
So my usecase is that a file is being uploaded to my rails server. Rails gives me a tempfile that I then want to upload to another service. I need to specify the filename and the content type of the file when I upload it to the other service using multi-part form data. By adding the `params_encoding` `:none` option it allows me to specify all of the parts of the form data manually without needing to worry about the encoding munging things. This is what you can do once this is merged:

```ruby
Typhoeus::Request.new(
  url,
  params: {
    version: api_version
  },
  followlocation: true,
  method: :post,
  body: {
    file: [
      params[:file].original_filename,
      params[:file].content_type,
      params[:file].path
    ]
  },
  params_encoding: :none
)
```