### PR TITLE
Filename mimetype overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Gemfile.lock
 .yardoc
 doc
 coverage
+.idea

--- a/lib/ethon/easy/queryable.rb
+++ b/lib/ethon/easy/queryable.rb
@@ -129,16 +129,30 @@ module Ethon
         end
       end
       
-    def encode_multi_array_pairs(h, prefix, pairs)
-      h.each_with_index do |v, i|
-        key = prefix
-        pairs_for(v, key, pairs)
+      def encode_multi_array_pairs(h, prefix, pairs)
+        h.each_with_index do |v, i|
+          key = prefix
+          pairs_for(v, key, pairs)
+        end
       end
-    end
 
       def pairs_for(v, key, pairs)
         case v
-        when Hash, Array
+        when Hash
+
+          # If the hash element contains an entry named "filehandle" then we
+          # have a file with a potentially specified filename and mimetype.
+          # handle this special case.
+          if !v[:filehandle].nil? and v[:filehandle].is_a? File
+            fileinfo = file_info(v[:filehandle])
+
+            if !v[:filename].nil? then fileinfo[0] = v[:filename] end
+            if !v[:mimetype].nil? then fileinfo[1] = v[:mimetype] end
+            pairs << [key, fileinfo]
+          else
+            recursively_generate_pairs(v, key, pairs)
+          end
+        when Array
           recursively_generate_pairs(v, key, pairs)
         when File, Tempfile
           pairs << [key, file_info(v)]


### PR DESCRIPTION
I finally got around to doing this change... This allows you to do something akin to this:

        req = Typhoeus::Request.new('http://localhost:8081/',
                                method: :post,
                                body: { 
                                    test: 'test', 
                                    test2: 'test2',
                                    file: { handle: File.open('somefileondisk.bin', 'r'), filename: 'test.png' }
                                },
                                headers: { 'X-Test' => 'None' },
                                params: 'foo=bar',
                                followlocation: :redirects,
                                multipart: true);

    req.run

And will still upload the multipart file, but override the filename (and optionally the mimetype using the mimetype: parameter in the hash) from what would normally be pulled from file_info.

This is useful for anyone using the library who might need to control the filename and mimetype of the file being uploaded (we use it for security tests).