### PR TITLE
Make frozen-string-literal safe

### DIFF
--- a/lib/ethon/easy/callbacks.rb
+++ b/lib/ethon/easy/callbacks.rb
@@ -22,8 +22,8 @@ module Ethon
         Curl.set_option(:writefunction, body_write_callback, handle)
         Curl.set_option(:headerfunction, header_write_callback, handle)
         Curl.set_option(:debugfunction, debug_callback, handle)
-        @response_body = ""
-        @response_headers = ""
+        @response_body = String.new
+        @response_headers = String.new
         @headers_called = false
         @debug_info = Ethon::Easy::DebugInfo.new
       end

--- a/lib/ethon/easy/callbacks.rb
+++ b/lib/ethon/easy/callbacks.rb
@@ -22,8 +22,8 @@ module Ethon
         Curl.set_option(:writefunction, body_write_callback, handle)
         Curl.set_option(:headerfunction, header_write_callback, handle)
         Curl.set_option(:debugfunction, debug_callback, handle)
-        @response_body = String.new
-        @response_headers = String.new
+        @response_body = String.new("")
+        @response_headers = String.new("")
         @headers_called = false
         @debug_info = Ethon::Easy::DebugInfo.new
       end


### PR DESCRIPTION
Hey, thanks for the great work on this gem!

This PR makes Ethon work with `RUBYOPT="--enable-frozen-string-literal"`. Unfortunately, gems in the test suite are not frozen-string-literal safe, so you can't just run:

```ruby
RUBYOPT="--enable-frozen-string-literal" bundle exec rake
```

But you can create a test file:

```ruby
require "bundler/inline"

gemfile do
  source "https://rubygems.org"
  gem "ethon", path: "path/to/ethon"
end

easy = Ethon::Easy.new(url: "www.example.com")
p easy.perform
```

And run:

```sh
RUBYOPT="--enable-frozen-string-literal" ruby test.rb
```