### PR TITLE
Add support for CURLPIPE_MULTIPLEX

### DIFF
--- a/lib/ethon/curls/options.rb
+++ b/lib/ethon/curls/options.rb
@@ -211,7 +211,7 @@ module Ethon
 
       option :multi, :socketfunction, :callback, 1
       option :multi, :socketdata, :cbdata, 2
-      option :multi, :pipelining, :bool, 3
+      option :multi, :pipelining, :int, 3
       option :multi, :timerfunction, :callback, 4
       option :multi, :timerdata, :cbdata, 5
       option :multi, :maxconnects, :int, 6

--- a/lib/ethon/multi/options.rb
+++ b/lib/ethon/multi/options.rb
@@ -38,7 +38,7 @@ module Ethon
       #
       # @return [ void ]
       def pipelining=(value)
-        Curl.set_option(:pipelining, value_for(value, :bool), handle, :multi)
+        Curl.set_option(:pipelining, value_for(value, :int), handle, :multi)
       end
 
       # Sets socketdata option.


### PR DESCRIPTION
A new bitset `CURLPIPE_MULTIPLEX` was added to [the `CURLMOPT_PIPELINING` option](https://curl.haxx.se/libcurl/c/CURLMOPT_PIPELINING.html) in version 7.43.0, but at the time of writing `Ethon` only allowed for setting `0` (`CURLPIPE_NOTHING`) or `1` (`CURLPIPE_HTTP1`) to `CURLMOPT_PIPELINING`. This made sence when it only had two bitsets, but now there are three, and it makes more sense to use `:int` rather than `:bool`.

I confirmed multiplexing works as expected by running the following code:

```ruby
require 'ethon'

url = "https://www.google.com/"

multi = Ethon::Multi.new
multi.pipelining = 2

multi.add Ethon::Easy.new(url: url, verbose: true, http_version: :httpv2_0, pipewait: true)
multi.add Ethon::Easy.new(url: url, verbose: true, http_version: :httpv2_0, pipewait: true)
multi.add Ethon::Easy.new(url: url, verbose: true, http_version: :httpv2_0, pipewait: true)

multi.perform
```

## Output

<details><summary>With this PR</summary><p>

```
Found bundle for host www.google.com: 0x7fc07ae16c50 [serially]
Server doesn't support multi-use yet, wait
No connections available.
Found bundle for host www.google.com: 0x7fc07ae16c50 [serially]
Server doesn't support multi-use yet, wait
No connections available.
  Trying 216.58.219.196...
TCP_NODELAY set
Connected to www.google.com (216.58.219.196) port 443 (#0)
ALPN, offering h2
ALPN, offering http/1.1
Cipher selection: ALL:!EXPORT:!EXPORT40:!EXPORT56:!aNULL:!LOW:!RC4:@STRENGTH
successfully set certificate verify locations:
  CAfile: /etc/ssl/cert.pem
  CApath: none
TLSv1.2 (OUT), TLS handshake, Client hello (1):

(binary output reducted)

SSL connection using TLSv1.2 / ECDHE-ECDSA-AES128-GCM-SHA256
ALPN, server accepted to use h2
Server certificate:
 subject: C=US; ST=California; L=Mountain View; O=Google LLC; CN=www.google.com
 start date: Aug 28 18:23:00 2018 GMT
 expire date: Nov 20 18:23:00 2018 GMT
 subjectAltName: host "www.google.com" matched cert's "www.google.com"
 issuer: C=US; O=Google Trust Services; CN=Google Internet Authority G3
 SSL certificate verify ok.
Using HTTP2, server supports multi-use
Connection state changed (HTTP/2 confirmed)
Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
Using Stream ID: 1 (easy handle 0x7fc07b958000)
GET / HTTP/2
Host: www.google.com
Accept: */*

Found bundle for host www.google.com: 0x7fc07ae16c50 [can multiplex]
Conn: 0 (0x7fc07c007000) Receive pipe weight: (-1/0), penalized: FALSE
Multiplexed connection found!
Found connection 0, with requests in the pipe (1)
Re-using existing connection! (#0) with host www.google.com
Using Stream ID: 3 (easy handle 0x7fc07bb15e00)
GET / HTTP/2
Host: www.google.com
Accept: */*

Found bundle for host www.google.com: 0x7fc07ae16c50 [can multiplex]
Conn: 0 (0x7fc07c007000) Receive pipe weight: (-1/0), penalized: FALSE
Multiplexed connection found!
Found connection 0, with requests in the pipe (2)
Re-using existing connection! (#0) with host www.google.com
Using Stream ID: 5 (easy handle 0x7fc07c002000)
GET / HTTP/2
Host: www.google.com
Accept: */*

Connection state changed (MAX_CONCURRENT_STREAMS updated)!
HTTP/2 200
date: Thu, 20 Sep 2018 01:41:09 GMT
expires: -1
cache-control: private, max-age=0
content-type: text/html; charset=ISO-8859-1
p3p: CP="This is not a P3P policy! See g.co/p3phelp for more info."
server: gws
x-xss-protection: 1; mode=block
x-frame-options: SAMEORIGIN
set-cookie: 1P_JAR=2018-09-20-01; expires=Sat, 20-Oct-2018 01:41:09 GMT; path=/; domain=.google.com
set-cookie: NID=139=ptvT9toWoMKqbOcVPz_HZTT0OF7QQzfhuTZMHdbbCkMRR0hGByjBiWvEmwl-9V2B46fW04gxbY1O0TgXzY125rFfOjuvJPc1SP01DKb-SiONzhZYMs3jJbzWLZVysTca; expires=Fri, 22-Mar-2019 01:41:09 GMT; path=/; domain=.google.com; HttpOnly
alt-svc: quic=":443"; ma=2592000; v="44,43,39,35"
accept-ranges: none
vary: Accept-Encoding

HTTP/2 200
date: Thu, 20 Sep 2018 01:41:09 GMT
expires: -1
cache-control: private, max-age=0
content-type: text/html; charset=ISO-8859-1
p3p: CP="This is not a P3P policy! See g.co/p3phelp for more info."
server: gws
x-xss-protection: 1; mode=block
x-frame-options: SAMEORIGIN
set-cookie: 1P_JAR=2018-09-20-01; expires=Sat, 20-Oct-2018 01:41:09 GMT; path=/; domain=.google.com
set-cookie: NID=139=wJ-cI2D7727o9Kp5JFoWT1GXPUkGbAFDW7M5Hv8JEHU6MacMZHCtEBYldNEPZm1aZFa2EAIKqJvBX05_whBGcvdXrArLhVBaux9hdsczazTc_FA5lhYBj5Ce6ksakusA; expires=Fri, 22-Mar-2019 01:41:09 GMT; path=/; domain=.google.com; HttpOnly
alt-svc: quic=":443"; ma=2592000; v="44,43,39,35"
accept-ranges: none
vary: Accept-Encoding

HTTP/2 200
date: Thu, 20 Sep 2018 01:41:09 GMT
expires: -1
cache-control: private, max-age=0
content-type: text/html; charset=ISO-8859-1
p3p: CP="This is not a P3P policy! See g.co/p3phelp for more info."
server: gws
x-xss-protection: 1; mode=block
x-frame-options: SAMEORIGIN
set-cookie: 1P_JAR=2018-09-20-01; expires=Sat, 20-Oct-2018 01:41:09 GMT; path=/; domain=.google.com
set-cookie: NID=139=LRxjHD2aeUFN7mVg0S5W2kW9bnUE3XOKD4GohyG1husJcSjRy-vD5HnvBieQy6_3FKY337gRuaArN0mv9fKws3puZIYHfaXZD3m-IVSeQQpSmkTSUy_0BVnNYZ6QHu4v; expires=Fri, 22-Mar-2019 01:41:09 GMT; path=/; domain=.google.com; HttpOnly
alt-svc: quic=":443"; ma=2592000; v="44,43,39,35"
accept-ranges: none
vary: Accept-Encoding

Connection #0 to host www.google.com left intact
```

</details>


<details><summary>Without this PR</summary><p>

```
Found bundle for host www.google.com: 0x7fc9db2b39e0 [serially]
Found bundle for host www.google.com: 0x7fc9db2b39e0 [serially]
  Trying 172.217.12.164...
TCP_NODELAY set
Hostname 'www.google.com' was found in DNS cache
  Trying 172.217.12.164...
TCP_NODELAY set
Hostname 'www.google.com' was found in DNS cache
  Trying 172.217.12.164...
TCP_NODELAY set
Connected to www.google.com (172.217.12.164) port 443 (#2)
ALPN, offering h2
ALPN, offering http/1.1
Cipher selection: ALL:!EXPORT:!EXPORT40:!EXPORT56:!aNULL:!LOW:!RC4:@STRENGTH
successfully set certificate verify locations:
  CAfile: /etc/ssl/cert.pem
  CApath: none
TLSv1.2 (OUT), TLS handshake, Client hello (1):

(binary output reducted)

ALPN, server accepted to use h2
Server certificate:
 subject: C=US; ST=California; L=Mountain View; O=Google LLC; CN=www.google.com
 start date: Aug 28 18:23:00 2018 GMT
 expire date: Nov 20 18:23:00 2018 GMT
 subjectAltName: host "www.google.com" matched cert's "www.google.com"
 issuer: C=US; O=Google Trust Services; CN=Google Internet Authority G3
 SSL certificate verify ok.
Using HTTP2, server supports multi-use
Connection state changed (HTTP/2 confirmed)
Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
Using Stream ID: 1 (easy handle 0x7fc9d9203800)
GET / HTTP/2
Host: www.google.com
Accept: */*

TLSv1.2 (IN), TLS change cipher, Client hello (1):
TLSv1.2 (IN), TLS handshake, Finished (20):

ALPN, server accepted to use h2
Server certificate:
 subject: C=US; ST=California; L=Mountain View; O=Google LLC; CN=www.google.com
 start date: Aug 28 18:23:00 2018 GMT
 expire date: Nov 20 18:23:00 2018 GMT
 subjectAltName: host "www.google.com" matched cert's "www.google.com"
 issuer: C=US; O=Google Trust Services; CN=Google Internet Authority G3
 SSL certificate verify ok.
Using HTTP2, server supports multi-use
Connection state changed (HTTP/2 confirmed)
Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
Using Stream ID: 1 (easy handle 0x7fc9d902e600)
GET / HTTP/2
Host: www.google.com
Accept: */*

TLSv1.2 (IN), TLS change cipher, Client hello (1):
TLSv1.2 (IN), TLS handshake, Finished (20):


ALPN, server accepted to use h2
Server certificate:
 subject: C=US; ST=California; L=Mountain View; O=Google LLC; CN=www.google.com
 start date: Aug 28 18:23:00 2018 GMT
 expire date: Nov 20 18:23:00 2018 GMT
 subjectAltName: host "www.google.com" matched cert's "www.google.com"
 issuer: C=US; O=Google Trust Services; CN=Google Internet Authority G3
 SSL certificate verify ok.
Using HTTP2, server supports multi-use
Connection state changed (HTTP/2 confirmed)
Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
Using Stream ID: 1 (easy handle 0x7fc9d91fa600)
GET / HTTP/2
Host: www.google.com
Accept: */*

Connection state changed (MAX_CONCURRENT_STREAMS updated)!
Connection state changed (MAX_CONCURRENT_STREAMS updated)!
Connection state changed (MAX_CONCURRENT_STREAMS updated)!
HTTP/2 200
date: Thu, 20 Sep 2018 01:46:28 GMT
expires: -1
cache-control: private, max-age=0
content-type: text/html; charset=ISO-8859-1
p3p: CP="This is not a P3P policy! See g.co/p3phelp for more info."
server: gws
x-xss-protection: 1; mode=block
x-frame-options: SAMEORIGIN
set-cookie: 1P_JAR=2018-09-20-01; expires=Sat, 20-Oct-2018 01:46:28 GMT; path=/; domain=.google.com
set-cookie: NID=139=S806sKCxJGNPWfCZj8c5vpBjaddV0oIxrfcDUjQW5_3pE7qmM9NTEUwzRc27Y3ukOiM2oI_Rqr5H0Q8IMXZG9b7_DAzmLlH8Xb6XO_lCxYgSfUKC_hQ9O6rKNm-RtTr5; expires=Fri, 22-Mar-2019 01:46:28 GMT; path=/; domain=.google.com; HttpOnly
alt-svc: quic=":443"; ma=2592000; v="44,43,39,35"
accept-ranges: none
vary: Accept-Encoding

HTTP/2 200
date: Thu, 20 Sep 2018 01:46:28 GMT
expires: -1
cache-control: private, max-age=0
content-type: text/html; charset=ISO-8859-1
p3p: CP="This is not a P3P policy! See g.co/p3phelp for more info."
server: gws
x-xss-protection: 1; mode=block
x-frame-options: SAMEORIGIN
set-cookie: 1P_JAR=2018-09-20-01; expires=Sat, 20-Oct-2018 01:46:28 GMT; path=/; domain=.google.com
set-cookie: NID=139=mkG_cgKOcCWdFATdmqTnrclGhZVmKbCpso5LQ6B70S9Q4zaOkpvKd6nxF48cx99zljWqND8y1g_qoi0k8jEQl0ut4nbwvuC26RtLkYIQQyrmCj_PoT9xIorVWWpd6GC_; expires=Fri, 22-Mar-2019 01:46:28 GMT; path=/; domain=.google.com; HttpOnly
alt-svc: quic=":443"; ma=2592000; v="44,43,39,35"
accept-ranges: none
vary: Accept-Encoding

HTTP/2 200
date: Thu, 20 Sep 2018 01:46:28 GMT
expires: -1
cache-control: private, max-age=0
content-type: text/html; charset=ISO-8859-1
p3p: CP="This is not a P3P policy! See g.co/p3phelp for more info."
server: gws
x-xss-protection: 1; mode=block
x-frame-options: SAMEORIGIN
set-cookie: 1P_JAR=2018-09-20-01; expires=Sat, 20-Oct-2018 01:46:28 GMT; path=/; domain=.google.com
set-cookie: NID=139=yTqZ-JEe9xN_tBR6DY8b6SKQgStJ0rl1dZ80djcEsL70P5d7W1NfGGzf95_qQv-gsA47LGMQFBwgIOIs5qR58nAhJPg5MvETYQU97bpqKrSMNRRKOYbTSAV7COpV1KNi; expires=Fri, 22-Mar-2019 01:46:28 GMT; path=/; domain=.google.com; HttpOnly
alt-svc: quic=":443"; ma=2592000; v="44,43,39,35"
accept-ranges: none
vary: Accept-Encoding

Connection #1 to host www.google.com left intact
Connection #2 to host www.google.com left intact
Connection #0 to host www.google.com left intact
```

</details>

<hr />

The logs are quite long, but notice the presence of `Multiplexed connection found!` in the second and third calls:

![carbon__1_](https://user-images.githubusercontent.com/386234/45791322-298bbb00-bc57-11e8-8585-2fb581126a35.png)