### PR TITLE
Create a block-based setter for debug_callback functions

### DIFF
--- a/lib/ethon/easy/options.rb
+++ b/lib/ethon/easy/options.rb
@@ -36,12 +36,14 @@ module Ethon
             value
           end
         end
-        next if props[:type] != :callback || method_defined?(opt)
-        define_method(opt) do |&block|
-          @procs ||= {}
-          @procs[opt.to_sym] = block
-          Curl.set_option(opt, block, handle)
-          nil
+
+        if %i(callback debug_callback).include?(props[:type]) && !method_defined?(opt)
+          define_method(opt) do |&block|
+            @procs ||= {}
+            @procs[opt.to_sym] = block
+            Curl.set_option(opt, block, handle)
+            nil
+          end
         end
       end
     end


### PR DESCRIPTION
This defines setters for debug_callback functions the same way as callback functions. This is useful for setting CURL_DEBUGFUNCTION

```ruby
curl = Ethon::Easy.new(...)
curl.debugfunction do |_, _, _, _, _|
  ...
end
```