### PR TITLE
Allow users to request additional infos from easy

### DIFF
--- a/lib/ethon/easy/mirror.rb
+++ b/lib/ethon/easy/mirror.rb
@@ -4,8 +4,21 @@ module Ethon
       attr_reader :options
       alias_method :to_hash, :options
 
-      INFORMATIONS_TO_MIRROR = Informations::AVAILABLE_INFORMATIONS.keys +
-          [:return_code, :response_headers, :response_body, :debug_info]
+      INFORMATIONS_TO_MIRROR = []
+
+      def self.mirror_information(info)
+        INFORMATIONS_TO_MIRROR << info
+        define_method(info) { options[info] }
+      end
+
+      Informations::AVAILABLE_INFORMATIONS.keys.each do |info|
+        mirror_information(info)
+      end
+
+      mirror_information(:return_code)
+      mirror_information(:response_headers)
+      mirror_information(:response_body)
+      mirror_information(:debug_info)
 
       INFORMATIONS_TO_LOG = [:effective_url, :response_code, :return_code, :total_time]
 
@@ -25,10 +38,6 @@ module Ethon
         Hash[*INFORMATIONS_TO_LOG.map do |info|
           [info, options[info]]
         end.flatten]
-      end
-
-      INFORMATIONS_TO_MIRROR.each do |info|
-        eval %Q|def #{info}; options[#{info}]; end|
       end
     end
   end


### PR DESCRIPTION
Many "infos" aren't currently accessible using Typhoeus. This PR allows users to request additional infos be made available on responses. I can't find any other way to get these infos, since the `Easy` is reset when being added back to the pool.

With this change, additional infos could be captured by calling `Ethon::Easy::Mirror.mirror_information(:info_i_want)`.