### PR TITLE
Add ability to abort request on headers callback. Closes typhoeus/typhoeus#511

### DIFF
--- a/lib/ethon/easy/callbacks.rb
+++ b/lib/ethon/easy/callbacks.rb
@@ -51,8 +51,9 @@ module Ethon
       # @return [ Proc ] The callback.
       def header_write_callback
         @header_write_callback ||= proc {|stream, size, num, object|
+          result = headers
           @response_headers << stream.read_string(size * num)
-          size * num
+          result != :abort ? size * num : -1
         }
       end
 

--- a/lib/ethon/easy/response_callbacks.rb
+++ b/lib/ethon/easy/response_callbacks.rb
@@ -42,7 +42,12 @@ module Ethon
         return if @headers_called
         @headers_called = true
         if defined?(@on_headers) and not @on_headers.nil?
-          @on_headers.each{ |callback| callback.call(self) }
+          result = nil
+          @on_headers.each do |callback|
+            result = callback.call(self)
+            break if result == :abort
+          end
+          result
         end
       end
 

--- a/spec/ethon/easy/callbacks_spec.rb
+++ b/spec/ethon/easy/callbacks_spec.rb
@@ -55,4 +55,26 @@ describe Ethon::Easy::Callbacks do
       end
     end
   end
+
+  describe "#header_write_callback" do
+    let(:header_write_callback) { easy.instance_variable_get(:@header_write_callback) }
+    let(:stream) { double(:read_string => "") }
+    context "when header returns not :abort" do
+      it "returns number bigger than 0" do
+        expect(header_write_callback.call(stream, 1, 1, nil) > 0).to be(true)
+      end
+    end
+
+    context "when header returns :abort" do
+      before do
+        easy.on_headers.clear
+        easy.on_headers { :abort }
+      end
+      let(:header_write_callback) { easy.instance_variable_get(:@header_write_callback) }
+
+      it "returns -1 to indicate abort to libcurl" do
+        expect(header_write_callback.call(stream, 1, 1, nil)).to eq(-1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Since https://github.com/typhoeus/ethon/pull/143 was closed by the author I decided to make my own PR for this.

The `header_write_callback` function works the same way as the `body_write_callback`, libcurl will abort if the returned number of read bytes differs from the number passed in:
https://curl.haxx.se/libcurl/c/CURLOPT_HEADERFUNCTION.html

This is my first time using and looking at typhoeus/ethon code, so please review it carefully as I'm not familiar with the code base :/ For example, it's not clear to me why `headers` is called from the `body_write_callback` function.

Closes https://github.com/typhoeus/typhoeus/issues/511