### PR TITLE
Replace deprecated getdtablesize with sysconf

### DIFF
--- a/lib/ethon.rb
+++ b/lib/ethon.rb
@@ -1,5 +1,6 @@
 require 'logger'
 require 'ffi'
+require 'ffi/tools/const_generator'
 require 'thread'
 begin
   require 'mime/types/columnar'

--- a/lib/ethon/curls/classes.rb
+++ b/lib/ethon/curls/classes.rb
@@ -32,7 +32,7 @@ module Ethon
         def clear; self[:fd_count] = 0; end
       else
         # FD Set size.
-        FD_SETSIZE = ::Ethon::Libc.getdtablesize
+        FD_SETSIZE = ::Ethon::Libc.sysconf(:open_max)
         layout :fds_bits, [:long, FD_SETSIZE / ::FFI::Type::LONG.size]
 
         # :nodoc:

--- a/lib/ethon/libc.rb
+++ b/lib/ethon/libc.rb
@@ -13,7 +13,21 @@ module Ethon
     end
 
     unless windows?
-      attach_function :getdtablesize, [], :int
+      fcg = FFI::ConstGenerator.new do |gen|
+        gen.include 'unistd.h'
+        %w[
+          _SC_OPEN_MAX
+        ].each do |const|
+          ruby_name = const.sub(/^_SC_/, '').downcase.to_sym
+          gen.const(const, "%d", nil, ruby_name, &:to_i)
+        end
+      end
+
+      CONF = enum(*fcg.constants.map{|_, const|
+        [const.ruby_name, const.converted_value]
+      }.flatten)
+
+      attach_function :sysconf, [CONF], :long
       attach_function :free, [:pointer], :void
     end
   end

--- a/spec/ethon/libc_spec.rb
+++ b/spec/ethon/libc_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
 describe Ethon::Libc do
-  describe "#getdtablesize", :if => !Ethon::Curl.windows? do
+  describe "#sysconf(:open_max)", :if => !Ethon::Curl.windows? do
     it "returns an integer" do
-      expect(Ethon::Libc.getdtablesize).to be_a(Integer)
+      expect(Ethon::Libc.sysconf(:open_max)).to be_a(Integer)
     end
 
     it "returns bigger zero", :if => !Ethon::Curl.windows? do
-      expect(Ethon::Libc.getdtablesize).to_not be_zero
+      expect(Ethon::Libc.sysconf(:open_max)).to_not be_zero
     end
   end
 end


### PR DESCRIPTION
As per the linux foundation deprecation note here:-
http://refspecs.linux-foundation.org/LSB_4.0.0/LSB-Core-generic/LSB-Core-generic/baselib-getdtablesize.html

This change keeps the gem up to date as this function is removed from
various platforms and allows it to run on aarch32/64.