### PR TITLE
Avoid mutating strings to support `--enable-frozen-string-literal`.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source "https://rubygems.org"
 gemspec
 

--- a/Guardfile
+++ b/Guardfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # vim:set filetype=ruby:
 guard(
   "rspec",

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "bundler"
 Bundler.setup
 

--- a/ethon.gemspec
+++ b/ethon.gemspec
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 lib = File.expand_path('../lib/', __FILE__)
 $:.unshift lib unless $:.include?(lib)
 

--- a/lib/ethon.rb
+++ b/lib/ethon.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'logger'
 require 'ffi'
 require 'ffi/tools/const_generator'

--- a/lib/ethon/curl.rb
+++ b/lib/ethon/curl.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'ethon/curls/codes'
 require 'ethon/curls/options'
 require 'ethon/curls/infos'

--- a/lib/ethon/curls/classes.rb
+++ b/lib/ethon/curls/classes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   module Curl
     # :nodoc:

--- a/lib/ethon/curls/codes.rb
+++ b/lib/ethon/curls/codes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   module Curls # :nodoc:
 

--- a/lib/ethon/curls/constants.rb
+++ b/lib/ethon/curls/constants.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   module Curl
     # :nodoc:

--- a/lib/ethon/curls/form_options.rb
+++ b/lib/ethon/curls/form_options.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   module Curls
 

--- a/lib/ethon/curls/functions.rb
+++ b/lib/ethon/curls/functions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   module Curls
 

--- a/lib/ethon/curls/infos.rb
+++ b/lib/ethon/curls/infos.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   module Curls
 

--- a/lib/ethon/curls/messages.rb
+++ b/lib/ethon/curls/messages.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   module Curls
 

--- a/lib/ethon/curls/options.rb
+++ b/lib/ethon/curls/options.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   module Curls
 

--- a/lib/ethon/curls/settings.rb
+++ b/lib/ethon/curls/settings.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   module Curl
     callback :callback, [:pointer, :size_t, :size_t, :pointer], :size_t

--- a/lib/ethon/easy.rb
+++ b/lib/ethon/easy.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'ethon/easy/informations'
 require 'ethon/easy/features'
 require 'ethon/easy/callbacks'

--- a/lib/ethon/easy/callbacks.rb
+++ b/lib/ethon/easy/callbacks.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   class Easy
 
@@ -22,8 +23,8 @@ module Ethon
         Curl.set_option(:writefunction, body_write_callback, handle)
         Curl.set_option(:headerfunction, header_write_callback, handle)
         Curl.set_option(:debugfunction, debug_callback, handle)
-        @response_body = ""
-        @response_headers = ""
+        @response_body = String.new
+        @response_headers = String.new
         @headers_called = false
         @debug_info = Ethon::Easy::DebugInfo.new
       end

--- a/lib/ethon/easy/debug_info.rb
+++ b/lib/ethon/easy/debug_info.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   class Easy
 

--- a/lib/ethon/easy/features.rb
+++ b/lib/ethon/easy/features.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   class Easy
 

--- a/lib/ethon/easy/form.rb
+++ b/lib/ethon/easy/form.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'ethon/easy/util'
 require 'ethon/easy/queryable'
 

--- a/lib/ethon/easy/header.rb
+++ b/lib/ethon/easy/header.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   class Easy
     # This module contains the logic around adding headers to libcurl.

--- a/lib/ethon/easy/http.rb
+++ b/lib/ethon/easy/http.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'ethon/easy/http/actionable'
 require 'ethon/easy/http/post'
 require 'ethon/easy/http/get'

--- a/lib/ethon/easy/http/actionable.rb
+++ b/lib/ethon/easy/http/actionable.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'ethon/easy/http/putable'
 require 'ethon/easy/http/postable'
 

--- a/lib/ethon/easy/http/custom.rb
+++ b/lib/ethon/easy/http/custom.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   class Easy
     module Http

--- a/lib/ethon/easy/http/delete.rb
+++ b/lib/ethon/easy/http/delete.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   class Easy
     module Http

--- a/lib/ethon/easy/http/get.rb
+++ b/lib/ethon/easy/http/get.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   class Easy
     module Http

--- a/lib/ethon/easy/http/head.rb
+++ b/lib/ethon/easy/http/head.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   class Easy
     module Http

--- a/lib/ethon/easy/http/options.rb
+++ b/lib/ethon/easy/http/options.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   class Easy
     module Http

--- a/lib/ethon/easy/http/patch.rb
+++ b/lib/ethon/easy/http/patch.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   class Easy
     module Http

--- a/lib/ethon/easy/http/post.rb
+++ b/lib/ethon/easy/http/post.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   class Easy
     module Http

--- a/lib/ethon/easy/http/postable.rb
+++ b/lib/ethon/easy/http/postable.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   class Easy
     module Http

--- a/lib/ethon/easy/http/put.rb
+++ b/lib/ethon/easy/http/put.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   class Easy
     module Http

--- a/lib/ethon/easy/http/putable.rb
+++ b/lib/ethon/easy/http/putable.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   class Easy
     module Http

--- a/lib/ethon/easy/informations.rb
+++ b/lib/ethon/easy/informations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   class Easy
 

--- a/lib/ethon/easy/mirror.rb
+++ b/lib/ethon/easy/mirror.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   class Easy
     class Mirror

--- a/lib/ethon/easy/operations.rb
+++ b/lib/ethon/easy/operations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   class Easy
     # This module contains the logic to prepare and perform

--- a/lib/ethon/easy/options.rb
+++ b/lib/ethon/easy/options.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   class Easy
 

--- a/lib/ethon/easy/params.rb
+++ b/lib/ethon/easy/params.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'ethon/easy/util'
 require 'ethon/easy/queryable'
 

--- a/lib/ethon/easy/queryable.rb
+++ b/lib/ethon/easy/queryable.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   class Easy
 

--- a/lib/ethon/easy/response_callbacks.rb
+++ b/lib/ethon/easy/response_callbacks.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   class Easy
 

--- a/lib/ethon/easy/util.rb
+++ b/lib/ethon/easy/util.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   class Easy # :nodoc:
 

--- a/lib/ethon/errors.rb
+++ b/lib/ethon/errors.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'ethon/errors/ethon_error'
 require 'ethon/errors/global_init'
 require 'ethon/errors/multi_timeout'

--- a/lib/ethon/errors/ethon_error.rb
+++ b/lib/ethon/errors/ethon_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   module Errors
 

--- a/lib/ethon/errors/global_init.rb
+++ b/lib/ethon/errors/global_init.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   module Errors
 

--- a/lib/ethon/errors/invalid_option.rb
+++ b/lib/ethon/errors/invalid_option.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   module Errors
 

--- a/lib/ethon/errors/invalid_value.rb
+++ b/lib/ethon/errors/invalid_value.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   module Errors
 

--- a/lib/ethon/errors/multi_add.rb
+++ b/lib/ethon/errors/multi_add.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   module Errors
 

--- a/lib/ethon/errors/multi_fdset.rb
+++ b/lib/ethon/errors/multi_fdset.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   module Errors
 

--- a/lib/ethon/errors/multi_remove.rb
+++ b/lib/ethon/errors/multi_remove.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   module Errors
 

--- a/lib/ethon/errors/multi_timeout.rb
+++ b/lib/ethon/errors/multi_timeout.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   module Errors
 

--- a/lib/ethon/errors/select.rb
+++ b/lib/ethon/errors/select.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   module Errors
 

--- a/lib/ethon/libc.rb
+++ b/lib/ethon/libc.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
 
   # FFI Wrapper module for Libc.

--- a/lib/ethon/loggable.rb
+++ b/lib/ethon/loggable.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 module Ethon
 
   # Contains logging behaviour.

--- a/lib/ethon/multi.rb
+++ b/lib/ethon/multi.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'ethon/easy/util'
 require 'ethon/multi/stack'
 require 'ethon/multi/operations'

--- a/lib/ethon/multi/operations.rb
+++ b/lib/ethon/multi/operations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   class Multi # :nodoc
     # This module contains logic to run a multi.

--- a/lib/ethon/multi/options.rb
+++ b/lib/ethon/multi/options.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   class Multi
 

--- a/lib/ethon/multi/stack.rb
+++ b/lib/ethon/multi/stack.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
   class Multi
 

--- a/lib/ethon/version.rb
+++ b/lib/ethon/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Ethon
 
   # Ethon version.

--- a/profile/benchmarks.rb
+++ b/profile/benchmarks.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'ethon'
 require 'open-uri'
 require 'patron'

--- a/profile/memory_leaks.rb
+++ b/profile/memory_leaks.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'ethon'
 require 'ethon/easy'
 

--- a/profile/perf_spec_helper.rb
+++ b/profile/perf_spec_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #### SETUP
 require 'bundler'
 Bundler.setup

--- a/profile/support/memory_test_helpers.rb
+++ b/profile/support/memory_test_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require_relative 'ruby_object_leak_tracker'
 require_relative 'os_memory_leak_tracker'
 

--- a/profile/support/os_memory_leak_tracker.rb
+++ b/profile/support/os_memory_leak_tracker.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class OSMemoryLeakTracker
   attr_reader :current_run
 

--- a/profile/support/ruby_object_leak_tracker.rb
+++ b/profile/support/ruby_object_leak_tracker.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class RubyObjectLeakTracker
   attr_reader :previous_count_hash, :current_count_hash
 

--- a/spec/ethon/curl_spec.rb
+++ b/spec/ethon/curl_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Curl do

--- a/spec/ethon/easy/callbacks_spec.rb
+++ b/spec/ethon/easy/callbacks_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Easy::Callbacks do

--- a/spec/ethon/easy/debug_info_spec.rb
+++ b/spec/ethon/easy/debug_info_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Easy::DebugInfo do

--- a/spec/ethon/easy/features_spec.rb
+++ b/spec/ethon/easy/features_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Easy::Informations do

--- a/spec/ethon/easy/form_spec.rb
+++ b/spec/ethon/easy/form_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Easy::Form do

--- a/spec/ethon/easy/header_spec.rb
+++ b/spec/ethon/easy/header_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Easy::Header do

--- a/spec/ethon/easy/http/custom_spec.rb
+++ b/spec/ethon/easy/http/custom_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Easy::Http::Custom do

--- a/spec/ethon/easy/http/delete_spec.rb
+++ b/spec/ethon/easy/http/delete_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Easy::Http::Delete do

--- a/spec/ethon/easy/http/get_spec.rb
+++ b/spec/ethon/easy/http/get_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Easy::Http::Get do

--- a/spec/ethon/easy/http/head_spec.rb
+++ b/spec/ethon/easy/http/head_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Easy::Http::Head do

--- a/spec/ethon/easy/http/options_spec.rb
+++ b/spec/ethon/easy/http/options_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Easy::Http::Options do

--- a/spec/ethon/easy/http/patch_spec.rb
+++ b/spec/ethon/easy/http/patch_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Easy::Http::Patch do

--- a/spec/ethon/easy/http/post_spec.rb
+++ b/spec/ethon/easy/http/post_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Easy::Http::Post do

--- a/spec/ethon/easy/http/put_spec.rb
+++ b/spec/ethon/easy/http/put_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Easy::Http::Put do

--- a/spec/ethon/easy/http_spec.rb
+++ b/spec/ethon/easy/http_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Easy::Http do

--- a/spec/ethon/easy/informations_spec.rb
+++ b/spec/ethon/easy/informations_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Easy::Informations do

--- a/spec/ethon/easy/mirror_spec.rb
+++ b/spec/ethon/easy/mirror_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Easy::Mirror do

--- a/spec/ethon/easy/operations_spec.rb
+++ b/spec/ethon/easy/operations_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Easy::Operations do

--- a/spec/ethon/easy/options_spec.rb
+++ b/spec/ethon/easy/options_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Easy::Options do

--- a/spec/ethon/easy/queryable_spec.rb
+++ b/spec/ethon/easy/queryable_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Easy::Queryable do

--- a/spec/ethon/easy/response_callbacks_spec.rb
+++ b/spec/ethon/easy/response_callbacks_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Easy::ResponseCallbacks do

--- a/spec/ethon/easy/util_spec.rb
+++ b/spec/ethon/easy/util_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Easy::Util do

--- a/spec/ethon/easy_spec.rb
+++ b/spec/ethon/easy_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Easy do
@@ -106,8 +107,8 @@ describe Ethon::Easy do
       easy.on_complete { 'on_complete' }
       easy.on_headers { 'on_headers' }
       easy.on_progress { 'on_progress' }
-      easy.response_body = 'test_body'
-      easy.response_headers = 'test_headers'
+      easy.response_body = String.new('test_body')
+      easy.response_headers = String.new('test_headers')
       easy
     end
     let!(:e) { easy.dup }

--- a/spec/ethon/libc_spec.rb
+++ b/spec/ethon/libc_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Libc do

--- a/spec/ethon/loggable_spec.rb
+++ b/spec/ethon/loggable_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "spec_helper"
 
 describe Ethon::Loggable do

--- a/spec/ethon/multi/operations_spec.rb
+++ b/spec/ethon/multi/operations_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Multi::Operations do

--- a/spec/ethon/multi/options_spec.rb
+++ b/spec/ethon/multi/options_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Multi::Options do

--- a/spec/ethon/multi/stack_spec.rb
+++ b/spec/ethon/multi/stack_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Multi::Stack do

--- a/spec/ethon/multi_spec.rb
+++ b/spec/ethon/multi_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Ethon::Multi do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "..", "lib"))
 

--- a/spec/support/localhost_server.rb
+++ b/spec/support/localhost_server.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rack'
 require 'rack/handler/webrick'
 require 'net/http'

--- a/spec/support/server.rb
+++ b/spec/support/server.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 require 'json'
 require 'zlib'
 require 'sinatra/base'


### PR DESCRIPTION
Prior to this commit, projects that use Ethon were not able to use this
option because Ethon mutated a string that started as a literal. This
commit fixes the issue by initializing the mutable string with
`String.new` instead of `''`.

In addition, this updates Ethon to enforce this by adding a
`# frozen_string_literal: true` comment to the top of all ruby files.

Ideally, we could have set `RUBYOPT=--enable-frozen-string-literal`
in the CI builds for the project, but when I tried that I learned
that mustermann (a dependency of Sinatra, which Ethon uses in its
test suite to boot a web server) mutates some string literals. So
the best we can do until mustermann is fixed is to enforce it via
comments at the top of each Ruby source file.

Luckily, rubocop provides a way to add it automatically, which I used
for this:

```
$ rubocop --only Style/FrozenStringLiteralComment -A
```