### PR TITLE
Use the proper varargs definition of libcurl functions

### DIFF
--- a/ethon.gemspec
+++ b/ethon.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.license = 'MIT'
 
-  s.add_dependency('ffi', ['>= 1.3.0'])
+  s.add_dependency('ffi', ['>= 1.5.0'])
 
   s.files        = `git ls-files`.split("\n")
   s.test_files   = `git ls-files -- spec/*`.split("\n")

--- a/ethon.gemspec
+++ b/ethon.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.license = 'MIT'
 
-  s.add_dependency('ffi', ['>= 1.5.0'])
+  s.add_dependency('ffi', ['>= 1.15.0'])
 
   s.files        = `git ls-files`.split("\n")
   s.test_files   = `git ls-files -- spec/*`.split("\n")

--- a/lib/ethon/curls/functions.rb
+++ b/lib/ethon/curls/functions.rb
@@ -14,14 +14,8 @@ module Ethon
 
         base.attach_function :easy_init,                  :curl_easy_init,           [],                             :pointer
         base.attach_function :easy_cleanup,               :curl_easy_cleanup,        [:pointer],                     :void
-        base.attach_function :easy_getinfo,               :curl_easy_getinfo,        [:pointer, :info, :pointer],    :easy_code
-        base.attach_function :easy_setopt_ffipointer,     :curl_easy_setopt,         [:pointer, :easy_option, :pointer],  :easy_code
-        base.attach_function :easy_setopt_string,         :curl_easy_setopt,         [:pointer, :easy_option, :string],   :easy_code
-        base.attach_function :easy_setopt_long,           :curl_easy_setopt,         [:pointer, :easy_option, :long],     :easy_code
-        base.attach_function :easy_setopt_callback,       :curl_easy_setopt,         [:pointer, :easy_option, :callback], :easy_code
-        base.attach_function :easy_setopt_debug_callback, :curl_easy_setopt,         [:pointer, :easy_option, :debug_callback], :easy_code
-        base.attach_function :easy_setopt_progress_callback, :curl_easy_setopt,      [:pointer, :easy_option, :progress_callback], :easy_code
-        base.attach_function :easy_setopt_off_t,          :curl_easy_setopt,         [:pointer, :easy_option, :int64],    :easy_code
+        base.attach_function :easy_getinfo,               :curl_easy_getinfo,        [:pointer, :info, :varargs],    :easy_code
+        base.attach_function :easy_setopt,                :curl_easy_setopt,         [:pointer, :easy_option, :varargs], :easy_code
         base.instance_variable_set(:@blocking, true)
         base.attach_function :easy_perform,               :curl_easy_perform,        [:pointer],                     :easy_code
         base.attach_function :easy_strerror,              :curl_easy_strerror,       [:easy_code],                   :string
@@ -41,11 +35,7 @@ module Ethon
         base.attach_function :multi_timeout,              :curl_multi_timeout,       [:pointer, :pointer],           :multi_code
         base.attach_function :multi_fdset,                :curl_multi_fdset,         [:pointer, Curl::FDSet.ptr, Curl::FDSet.ptr, Curl::FDSet.ptr, :pointer], :multi_code
         base.attach_function :multi_strerror,             :curl_multi_strerror,      [:int],                         :string
-        base.attach_function :multi_setopt_ffipointer,    :curl_multi_setopt,        [:pointer, :multi_option, :pointer],  :multi_code
-        base.attach_function :multi_setopt_string,        :curl_multi_setopt,        [:pointer, :multi_option, :string],   :multi_code
-        base.attach_function :multi_setopt_long,          :curl_multi_setopt,        [:pointer, :multi_option, :long],     :multi_code
-        base.attach_function :multi_setopt_callback,      :curl_multi_setopt,        [:pointer, :multi_option, :callback], :multi_code
-        base.attach_function :multi_setopt_off_t,         :curl_multi_setopt,        [:pointer, :multi_option, :int64],    :multi_code
+        base.attach_function :multi_setopt,               :curl_multi_setopt,        [:pointer, :multi_option, :varargs], :multi_code
 
         base.attach_function :version,                    :curl_version,             [],                             :string
         base.attach_function :version_info,               :curl_version_info,        [],                             Curl::VersionInfoData.ptr

--- a/lib/ethon/curls/infos.rb
+++ b/lib/ethon/curls/infos.rb
@@ -107,7 +107,7 @@ module Ethon
       def get_info_string(option, handle)
         string_ptr = ::FFI::MemoryPointer.new(:pointer)
 
-        if easy_getinfo(handle, option, string_ptr) == :ok
+        if easy_getinfo(handle, option, :pointer, string_ptr) == :ok
           ptr=string_ptr.read_pointer
           ptr.null? ? nil : ptr.read_string
         end
@@ -125,7 +125,7 @@ module Ethon
       def get_info_long(option, handle)
         long_ptr = ::FFI::MemoryPointer.new(:long)
 
-        if easy_getinfo(handle, option, long_ptr) == :ok
+        if easy_getinfo(handle, option, :pointer, long_ptr) == :ok
           long_ptr.read_long
         end
       end
@@ -142,7 +142,7 @@ module Ethon
       def get_info_double(option, handle)
         double_ptr = ::FFI::MemoryPointer.new(:double)
 
-        if easy_getinfo(handle, option, double_ptr) == :ok
+        if easy_getinfo(handle, option, :pointer, double_ptr) == :ok
           double_ptr.read_double
         end
       end


### PR DESCRIPTION
closes #180

As explained in #180, the definition of some libcurl functions in `lib/ethon/curls/functions.rb` was not in line with the definition in the libcurl C headers. This PR fixes this problem.

As I was told in https://github.com/typhoeus/ethon/issues/180#issuecomment-788652324 that supporting older versions of ffi was not needed, so I tried to go for what seemed to end with the cleanest code, requiring ffi 1.5.0.

In the [patch](https://gist.github.com/vincentisambart/c78e9df22d0d4851c1e1d150ac26e5d1) I initially wrote and linked in the issue, I went for the safest route, only modifying `lib/ethon/curls/functions.rb`, adding `easy_setopt_*` and `multi_setopt_*` functions with the old signatures that called the new varargs version. This PR modifies more code and so is probably more risky, but I think in the long run it ends up with code more easy to follow. But if you want I can revert back to the safer change.

Note that as I'm writing this, it seems preparation for the release has started on the ffi repository, but ffi 1.5.0 has not been released yet. I'll remove the draft status of this PR as soon as ffi 1.5.0 is released.