### PR TITLE
Revert "Replace deprecated getdtablesize with sysconf"

### DIFF
--- a/lib/ethon.rb
+++ b/lib/ethon.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require 'logger'
 require 'ffi'
-require 'ffi/tools/const_generator'
 require 'thread'
 begin
   require 'mime/types/columnar'

--- a/lib/ethon/curls/classes.rb
+++ b/lib/ethon/curls/classes.rb
@@ -33,7 +33,7 @@ module Ethon
         def clear; self[:fd_count] = 0; end
       else
         # FD Set size.
-        FD_SETSIZE = ::Ethon::Libc.sysconf(:open_max)
+        FD_SETSIZE = ::Ethon::Libc.getdtablesize
         layout :fds_bits, [:long, FD_SETSIZE / ::FFI::Type::LONG.size]
 
         # :nodoc:

--- a/lib/ethon/libc.rb
+++ b/lib/ethon/libc.rb
@@ -14,21 +14,7 @@ module Ethon
     end
 
     unless windows?
-      fcg = FFI::ConstGenerator.new do |gen|
-        gen.include 'unistd.h'
-        %w[
-          _SC_OPEN_MAX
-        ].each do |const|
-          ruby_name = const.sub(/^_SC_/, '').downcase.to_sym
-          gen.const(const, "%d", nil, ruby_name, &:to_i)
-        end
-      end
-
-      CONF = enum(*fcg.constants.map{|_, const|
-        [const.ruby_name, const.converted_value]
-      }.flatten)
-
-      attach_function :sysconf, [CONF], :long
+      attach_function :getdtablesize, [], :int
       attach_function :free, [:pointer], :void
     end
   end

--- a/spec/ethon/libc_spec.rb
+++ b/spec/ethon/libc_spec.rb
@@ -2,13 +2,13 @@
 require 'spec_helper'
 
 describe Ethon::Libc do
-  describe "#sysconf(:open_max)", :if => !Ethon::Curl.windows? do
+  describe "#getdtablesize", :if => !Ethon::Curl.windows? do
     it "returns an integer" do
-      expect(Ethon::Libc.sysconf(:open_max)).to be_a(Integer)
+      expect(Ethon::Libc.getdtablesize).to be_a(Integer)
     end
 
     it "returns bigger zero", :if => !Ethon::Curl.windows? do
-      expect(Ethon::Libc.sysconf(:open_max)).to_not be_zero
+      expect(Ethon::Libc.getdtablesize).to_not be_zero
     end
   end
 end


### PR DESCRIPTION
Reverts typhoeus/ethon#166 - see #185 

Although I personally don't see this as an issue it's annoying for enough of people, so reverting.