### PR TITLE
Revert "Easy::Operations#handle: Thread-safe cleanup (#136)"

### DIFF
--- a/lib/ethon/easy/operations.rb
+++ b/lib/ethon/easy/operations.rb
@@ -4,20 +4,6 @@ module Ethon
     # This module contains the logic to prepare and perform
     # an easy.
     module Operations
-      
-      class PointerHelper
-        class<<self
-          def synchronize( &block )
-            (@mutex ||= Mutex.new).synchronize( &block )
-          end
-
-          def release( pointer )
-            synchronize { Curl.easy_cleanup pointer }
-          end
-        end
-        synchronize{}
-      end
-
       # Returns a pointer to the curl easy handle.
       #
       # @example Return the handle.
@@ -25,7 +11,7 @@ module Ethon
       #
       # @return [ FFI::Pointer ] A pointer to the curl easy handle.
       def handle
-        @handle ||= FFI::AutoPointer.new(Curl.easy_init, PointerHelper.method(:release) )
+        @handle ||= FFI::AutoPointer.new(Curl.easy_init, Curl.method(:easy_cleanup))
       end
 
       # Sets a pointer to the curl easy handle.


### PR DESCRIPTION
This reverts commit b4899b952f85d089358f599c71b0cf7b03db6c39.

Fix #194