### PR TITLE
Add optional socket_action mode to Ethon::Multi

### DIFF
--- a/lib/ethon/curls/constants.rb
+++ b/lib/ethon/curls/constants.rb
@@ -59,5 +59,22 @@ module Ethon
     VERSION_NTLM_WB = (1<<15) # NTLM delegating to winbind helper
     VERSION_HTTP2 = (1<<16) # HTTP2 support built
     VERSION_GSSAPI = (1<<17) # GSS-API is supported
+
+    SOCKET_BAD = -1
+    SOCKET_TIMEOUT = SOCKET_BAD
+
+    PollAction = enum(:poll_action, [
+      :none,
+      :in,
+      :out,
+      :inout,
+      :remove
+    ])
+
+    SocketReadiness = bitmask(:socket_readiness, [
+      :in,  # CURL_CSELECT_IN  - 0x01 (bit 0)
+      :out, # CURL_CSELECT_OUT - 0x02 (bit 1)
+      :err, # CURL_CSELECT_ERR - 0x04 (bit 2)
+    ])
   end
 end

--- a/lib/ethon/curls/functions.rb
+++ b/lib/ethon/curls/functions.rb
@@ -36,6 +36,7 @@ module Ethon
         base.attach_function :multi_fdset,                :curl_multi_fdset,         [:pointer, Curl::FDSet.ptr, Curl::FDSet.ptr, Curl::FDSet.ptr, :pointer], :multi_code
         base.attach_function :multi_strerror,             :curl_multi_strerror,      [:int],                         :string
         base.attach_function :multi_setopt,               :curl_multi_setopt,        [:pointer, :multi_option, :varargs], :multi_code
+        base.attach_function :multi_socket_action,        :curl_multi_socket_action, [:pointer, :int, :socket_readiness, :pointer], :multi_code
 
         base.attach_function :version,                    :curl_version,             [],                             :string
         base.attach_function :version_info,               :curl_version_info,        [],                             Curl::VersionInfoData.ptr

--- a/lib/ethon/curls/options.rb
+++ b/lib/ethon/curls/options.rb
@@ -82,6 +82,12 @@ module Ethon
         when :callback
           va_type=:callback
           raise Errors::InvalidValue.new(option,value) unless value.nil? or value.is_a? Proc
+        when :socket_callback
+          va_type=:socket_callback
+          raise Errors::InvalidValue.new(option,value) unless value.nil? or value.is_a? Proc
+        when :timer_callback
+          va_type=:timer_callback
+          raise Errors::InvalidValue.new(option,value) unless value.nil? or value.is_a? Proc
         when :debug_callback
           va_type=:debug_callback
           raise Errors::InvalidValue.new(option,value) unless value.nil? or value.is_a? Proc
@@ -137,6 +143,8 @@ module Ethon
         :dontuse_object => :objectpoint, # An object we don't support (e.g. FILE*)
         :cbdata => :objectpoint,
         :callback => :functionpoint,
+        :socket_callback => :functionpoint,
+        :timer_callback => :functionpoint,
         :debug_callback => :functionpoint,
         :progress_callback => :functionpoint,
         :off_t => :off_t,
@@ -208,10 +216,10 @@ module Ethon
       # Documentation @ http://curl.haxx.se/libcurl/c/curl_multi_setopt.html
       option_type :multi
 
-      option :multi, :socketfunction, :callback, 1
+      option :multi, :socketfunction, :socket_callback, 1
       option :multi, :socketdata, :cbdata, 2
       option :multi, :pipelining, :int, 3
-      option :multi, :timerfunction, :callback, 4
+      option :multi, :timerfunction, :timer_callback, 4
       option :multi, :timerdata, :cbdata, 5
       option :multi, :maxconnects, :int, 6
       option :multi, :max_host_connections, :int, 7

--- a/lib/ethon/curls/settings.rb
+++ b/lib/ethon/curls/settings.rb
@@ -2,6 +2,8 @@
 module Ethon
   module Curl
     callback :callback, [:pointer, :size_t, :size_t, :pointer], :size_t
+    callback :socket_callback, [:pointer, :int, :poll_action, :pointer, :pointer], :multi_code
+    callback :timer_callback, [:pointer, :long, :pointer], :multi_code
     callback :debug_callback, [:pointer, :debug_info_type, :pointer, :size_t, :pointer], :int
     callback :progress_callback, [:pointer, :long_long, :long_long, :long_long, :long_long], :int
     ffi_lib_flags :now, :global

--- a/lib/ethon/multi.rb
+++ b/lib/ethon/multi.rb
@@ -74,10 +74,21 @@ module Ethon
     # is 1 will not be treated as unlimited. Instead it will open only 1 
     # connection and try to pipeline on it.
     # (Added in 7.30.0)
+    # @option options :execution_mode [Boolean]
+    #  Either :perform (default) or :socket_action, specifies the usage
+    #  method that will be used on this multi object. The default :perform
+    #  mode provides a #perform function that uses curl_multi_perform
+    #  behind the scenes to automatically continue execution until all
+    #  requests have completed. The :socket_action mode provides an API
+    #  that allows the {Multi} object to be integrated into an external
+    #  IO loop, by calling #socket_action and responding to the 
+    #  socketfunction and timerfunction callbacks, using the underlying
+    #  curl_multi_socket_action semantics.
     #
     # @return [ Multi ] The new multi.
     def initialize(options = {})
       Curl.init
+      @execution_mode = options.delete(:execution_mode) || :perform
       set_attributes(options)
       init_vars
     end
@@ -99,6 +110,17 @@ module Ethon
         end
         method("#{key}=").call(value)
       end
+    end
+
+    private
+
+    # Internal function to gate functions to a specific execution mode
+    #
+    # @raise ArgumentError
+    #
+    # @api private
+    def ensure_execution_mode(expected_mode)
+      raise ArgumentError, "Expected the Multi to be in #{expected_mode} but it was in #{@execution_mode}" if expected_mode != @execution_mode
     end
   end
 end

--- a/lib/ethon/multi/operations.rb
+++ b/lib/ethon/multi/operations.rb
@@ -24,12 +24,16 @@ module Ethon
       #
       # @return [ void ]
       def init_vars
-        @timeout = ::FFI::MemoryPointer.new(:long)
-        @timeval = Curl::Timeval.new
-        @fd_read = Curl::FDSet.new
-        @fd_write = Curl::FDSet.new
-        @fd_excep = Curl::FDSet.new
-        @max_fd = ::FFI::MemoryPointer.new(:int)
+        if @execution_mode == :perform
+          @timeout = ::FFI::MemoryPointer.new(:long)
+          @timeval = Curl::Timeval.new
+          @fd_read = Curl::FDSet.new
+          @fd_write = Curl::FDSet.new
+          @fd_excep = Curl::FDSet.new
+          @max_fd = ::FFI::MemoryPointer.new(:int)
+        elsif @execution_mode == :socket_action
+          @running_count_pointer = FFI::MemoryPointer.new(:int)
+        end
       end
 
       # Perform multi.
@@ -39,6 +43,8 @@ module Ethon
       # @example Perform multi.
       #   multi.perform
       def perform
+        ensure_execution_mode(:perform)
+
         Ethon.logger.debug(STARTED_MULTI)
         while ongoing?
           run
@@ -67,9 +73,38 @@ module Ethon
         )
       end
 
-      private
+      # Continue execution with an external IO loop.
+      #
+      # @example When no sockets are ready yet, or to begin.
+      #   multi.socket_action
+      #
+      # @example When a socket is readable
+      #   multi.socket_action(io_object, [:in])
+      #
+      # @example When a socket is readable and writable
+      #   multi.socket_action(io_object, [:in, :out])
+      #
+      # @return [ Symbol ] The Curl.multi_socket_action return code.
+      def socket_action(io = nil, readiness = 0)
+        ensure_execution_mode(:socket_action)
 
-      # Return wether the multi still requests or not.
+        fd = if io.nil?
+          ::Ethon::Curl::SOCKET_TIMEOUT
+        elsif io.is_a?(Integer)
+          io
+        else
+          io.fileno
+        end
+
+        code = Curl.multi_socket_action(handle, fd, readiness, @running_count_pointer)
+        @running_count = @running_count_pointer.read_int
+
+        check
+
+        code
+      end
+
+      # Return whether the multi still contains requests or not.
       #
       # @example Return if ongoing.
       #   multi.ongoing?
@@ -78,6 +113,8 @@ module Ethon
       def ongoing?
         easy_handles.size > 0 || (!defined?(@running_count) || running_count > 0)
       end
+
+      private
 
       # Get timeout.
       #

--- a/spec/ethon/multi_spec.rb
+++ b/spec/ethon/multi_spec.rb
@@ -85,8 +85,6 @@ describe Ethon::Multi do
       multi.socket_action # start things off
 
       while multi.ongoing?
-        break if select_state[:readers].empty? && select_state[:writers].empty?
-        
         readers, writers, _ = IO.select(
           fds_to_ios(select_state[:readers]),
           fds_to_ios(select_state[:writers]),
@@ -112,6 +110,10 @@ describe Ethon::Multi do
 
         # if we didn't have anything to notify, then we timed out
         multi.socket_action if to_notify.empty?
+      end
+    ensure
+      multi.easy_handles.dup.each do |h|
+        multi.delete(h)
       end
     end
 

--- a/spec/ethon/multi_spec.rb
+++ b/spec/ethon/multi_spec.rb
@@ -8,6 +8,16 @@ describe Ethon::Multi do
       Ethon::Multi.new
     end
 
+    context "with default options" do
+      it "allows running #perform with the default execution_mode" do
+        Ethon::Multi.new.perform
+      end
+
+      it "refuses to run #socket_action" do
+        expect { Ethon::Multi.new.socket_action }.to raise_error(ArgumentError)
+      end
+    end
+
     context "when options not empty" do
       context "when pipelining is set" do
         let(:options) { { :pipelining => true } }
@@ -16,6 +26,124 @@ describe Ethon::Multi do
           expect_any_instance_of(Ethon::Multi).to receive(:pipelining=).with(true)
           Ethon::Multi.new(options)
         end
+      end
+
+      context "when execution_mode option is :socket_action" do
+        let(:options) { { :execution_mode => :socket_action } }
+        let(:multi) { Ethon::Multi.new(options) }
+
+        it "refuses to run #perform" do
+          expect { multi.perform }.to raise_error(ArgumentError)
+        end
+
+        it "allows running #socket_action" do
+          multi.socket_action
+        end
+      end
+    end
+  end
+
+  describe "#socket_action" do
+    let(:options) { { :execution_mode => :socket_action } }
+    let(:select_state) { { :readers => [], :writers => [], :timeout => 0 } }
+    let(:multi) {
+      multi = Ethon::Multi.new(options)
+      multi.timerfunction = proc do |handle, timeout_ms, userp|
+        timeout_ms = nil if timeout_ms == -1
+        select_state[:timeout] = timeout_ms
+        :ok
+      end
+      multi.socketfunction = proc do |handle, sock, what, userp, socketp|
+        case what
+        when :remove
+          select_state[:readers].delete(sock)
+          select_state[:writers].delete(sock)
+        when :in
+          select_state[:readers].push(sock) unless select_state[:readers].include? sock
+          select_state[:writers].delete(sock)
+        when :out
+          select_state[:readers].delete(sock)
+          select_state[:writers].push(sock) unless select_state[:writers].include? sock
+        when :inout
+          select_state[:readers].push(sock) unless select_state[:readers].include? sock
+          select_state[:writers].push(sock) unless select_state[:writers].include? sock
+        else
+          raise ArgumentError, "invalid value for 'what' in socketfunction callback"
+        end
+        :ok
+      end
+      multi
+    }
+
+    def fds_to_ios(fds)
+      fds.map do |fd|
+        IO.for_fd(fd).tap { |io| io.autoclose = false }
+      end
+    end
+
+    def perform_socket_action_until_complete
+      multi.socket_action # start things off
+
+      while multi.ongoing?
+        break if select_state[:readers].empty? && select_state[:writers].empty?
+        
+        readers, writers, _ = IO.select(
+          fds_to_ios(select_state[:readers]),
+          fds_to_ios(select_state[:writers]),
+          [],
+          select_state[:timeout]
+        )
+
+        to_notify = Hash.new { |hash, key| hash[key] = [] }
+        unless readers.nil?
+          readers.each do |reader|
+            to_notify[reader] << :in
+          end
+        end
+        unless writers.nil?
+          writers.each do |writer|
+            to_notify[writer] << :out
+          end
+        end
+
+        to_notify.each do |io, readiness|
+          multi.socket_action(io, readiness)
+        end
+
+        # if we didn't have anything to notify, then we timed out
+        multi.socket_action if to_notify.empty?
+      end
+    end
+
+    it "supports an end-to-end request" do
+      easy = Ethon::Easy.new
+      easy.url = "http://localhost:3001/"
+      multi.add(easy)
+
+      perform_socket_action_until_complete
+
+      expect(multi.ongoing?).to eq(false)
+    end
+
+    it "supports multiple concurrent requests" do
+      handles = []
+      10.times do
+        easy = Ethon::Easy.new
+        easy.url = "http://localhost:3001/?delay=1"
+        multi.add(easy)
+        handles << easy
+      end
+
+      start = Time.now
+      perform_socket_action_until_complete
+      duration = Time.now - start
+      
+      # these should have happened concurrently
+      expect(duration).to be < 2
+      expect(multi.ongoing?).to eq(false)
+
+      handles.each do |handle|
+        expect(handle.response_code).to eq(200)
       end
     end
   end


### PR DESCRIPTION
This PR implements bindings for `curl_multi_socket_action` on the `Ethon::Multi` object, allowing simple integration between Ethon and an external IO loop.

This primarily introduces a new `execution_mode` option which, when provided, changes the `Multi` object from having a complete internal `perform` implementation with `curl_multi_perform`, to an externally driven one using `curl_multi_socket_action` by calling `socket_action` any time a socket is ready, or when it times out. The ability to choose between the `perform` and `socket_action` aligns with the way underlying Curl multi objects work, and the calling pattern for `Multi#socket_action` aligns with the [typical usage documented in curl](https://curl.se/libcurl/c/curl_multi_socket_action.html).

As part of this change, this PR also corrects the type signatures of the `timerfunction` and `socketfunction` callbacks to ensure their arguments are decoded correctly (which was not the case previously).

There is a complete end-to-end test of single and concurrent requests in `spec/ethon/multi_spec.rb` which demonstrates the full API. The API additions should be backwards compatible and default to the existing `perform` based method, other than the callback argument types which are now more correct (though `socketfunction` was only used with `socket_action`, so is unlikely to be used before this PR's changes). The `Multi#ongoing?` function has been made public so that an external loop may check if work is still required.

The end result of this change is that the backing execution can be integrated into an external IO loop like [nio4r](https://github.com/socketry/nio4r) trivially, although the API is not tied to any particular IO event loop, matching the flexibility of curl's underlying `curl_multi_socket_action`.