### PR TITLE
Add :tcp_fastopen option

### DIFF
--- a/lib/ethon/curls/options.rb
+++ b/lib/ethon/curls/options.rb
@@ -307,6 +307,7 @@ module Ethon
       option :easy, :port, :int, 3
       option :easy, :tcp_nodelay, :bool, 121
       option :easy, :address_scope, :int, 171
+      option :easy, :tcp_fastopen, :bool, 212
       option :easy, :tcp_keepalive, :bool, 213
       option :easy, :tcp_keepidle, :int, 214
       option :easy, :tcp_keepintvl, :int, 215


### PR DESCRIPTION
Support for TCP Fast Open (TFO) was added to libcurl in version [7.49.0][1] through [`CURLOPT_TCP_FASTOPTION`][2].

[1]: https://github.com/curl/curl/blob/curl-7_49_0/docs/libcurl/symbols-in-versions#L541
[2]: https://curl.se/libcurl/c/CURLOPT_TCP_FASTOPEN.html
