### PR TITLE
Exclude truffleruby-head because it is failing

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        ruby-version: [2.5, 2.6, 2.7, 3.0, head, debug, truffleruby, truffleruby-head]
+        ruby-version: [2.5, 2.6, 2.7, 3.0, head, debug, truffleruby]
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Hi team,

what are you thinking about excluding `truffleruby-head` because it is failing on `macos` constantly. I don't have a strong opinion on this, just noticed the failures when I checked master.