### PR TITLE
FD Size: Add default cap of 65536 and ETHON_FD_SIZE to override it

### DIFF
--- a/lib/ethon/curls/classes.rb
+++ b/lib/ethon/curls/classes.rb
@@ -32,8 +32,18 @@ module Ethon
 
         def clear; self[:fd_count] = 0; end
       else
-        # FD Set size.
-        FD_SETSIZE = ::Ethon::Libc.getdtablesize
+        # https://github.com/typhoeus/ethon/issues/182
+        FD_SETSIZE = begin
+          # Allow to override the (new) default cap
+          if ENV['ETHON_FD_SIZE']
+            ENV['ETHON_FD_SIZE']
+
+          # auto-detect ulimit, but cap at 2^16
+          else
+            [::Ethon::Libc.getdtablesize, 65_536].min
+          end
+        end
+
         layout :fds_bits, [:long, FD_SETSIZE / ::FFI::Type::LONG.size]
 
         # :nodoc:


### PR DESCRIPTION
Proposal to solve #182 