### PR TITLE
Add `redirect_url` value to available informations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 [Full Changelog](https://github.com/typhoeus/ethon/compare/v0.15.0...master)
 
+* Added `redirect_url` value to available informations and `Easy::Mirror`.
+  ([Adrien Rey-Jarthon](https://github.com/jarthod)
+
 ## 0.15.0
 
 [Full Changelog](https://github.com/typhoeus/ethon/compare/v0.14.0...v0.15.0)

--- a/lib/ethon/easy/informations.rb
+++ b/lib/ethon/easy/informations.rb
@@ -73,6 +73,9 @@ module Ethon
         # actually followed.
         :redirect_count => :long,
 
+        # URL a redirect would take you to, had you enabled redirects (Added in 7.18.2)
+        :redirect_url => :string,
+
         # Return the bytes, the total amount of bytes that were uploaded
         :size_upload => :double,
 

--- a/spec/ethon/easy/informations_spec.rb
+++ b/spec/ethon/easy/informations_spec.rb
@@ -81,6 +81,12 @@ describe Ethon::Easy::Informations do
     end
   end
 
+  describe "#redirect_url" do
+    it "returns nil as there is no redirect" do
+      expect(easy.redirect_url).to be(nil)
+    end
+  end
+
   describe "#request_size" do
     it "returns 53" do
       expect(easy.request_size).to eq(53)

--- a/spec/ethon/easy/mirror_spec.rb
+++ b/spec/ethon/easy/mirror_spec.rb
@@ -11,7 +11,7 @@ describe Ethon::Easy::Mirror do
       :total_time, :starttransfer_time, :appconnect_time,
       :pretransfer_time, :connect_time, :namelookup_time, :redirect_time,
       :size_upload, :size_download, :speed_upload, :speed_upload,
-      :effective_url, :primary_ip, :redirect_count, :debug_info
+      :effective_url, :primary_ip, :redirect_count, :redirect_url, :debug_info
     ].each do |name|
       it "contains #{name}" do
         expect(described_class::INFORMATIONS_TO_MIRROR).to include(name)

--- a/spec/ethon/easy/operations_spec.rb
+++ b/spec/ethon/easy/operations_spec.rb
@@ -106,6 +106,7 @@ describe Ethon::Easy::Operations do
 
         it "doesn't follow" do
           expect(easy.response_code).to eq(302)
+          expect(easy.redirect_url).to eq("http://localhost:3001/")
         end
       end
 
@@ -115,6 +116,7 @@ describe Ethon::Easy::Operations do
 
         it "follows" do
           expect(easy.response_code).to eq(200)
+          expect(easy.redirect_url).to eq(nil)
         end
 
         context "when infinite redirect loop" do
@@ -124,6 +126,7 @@ describe Ethon::Easy::Operations do
           context "when max redirect set" do
             it "follows only x times" do
               expect(easy.response_code).to eq(302)
+              expect(easy.redirect_url).to eq("http://localhost:3001/bad_redirect")
             end
           end
         end


### PR DESCRIPTION
Similar to my previous PR (#101), I am adding the `redirect_url` field to available information (and will follow up with a Typhoeus PR). This fiels is useful when you need to implement redirection on your end: https://curl.se/libcurl/c/CURLINFO_REDIRECT_URL.html