### PR TITLE
Allow sending headers with empty values

### DIFF
--- a/lib/ethon/easy/header.rb
+++ b/lib/ethon/easy/header.rb
@@ -54,7 +54,7 @@ module Ethon
       #
       # @return [ String ] The composed header.
       def compose_header(key, value)
-        Util.escape_zero_byte("#{key}: #{value}")
+        Util.escape_zero_byte(key.to_s[-1] == ';' && value.to_s.empty? ? "#{key}" : "#{key}: #{value}")
       end
     end
   end


### PR DESCRIPTION
Allow sending headers with empty values,
while also allowing the user to remove default headers set by libcurl.
 See [https://curl.se/libcurl/c/CURLOPT_HTTPHEADER.html](https://curl.se/libcurl/c/CURLOPT_HTTPHEADER.html) for more details.

Passing `headers: {'h1' => 'v1', 'h2' => '', 'h3;' => ''}`
corresponds to these curl options: `-H 'h1: v1' -H 'h2:'  -H 'h3;'`

Enhances #132
Fixes typhoeus/typhoeus#706