### PR TITLE
Remove development and test files from the gem package

### DIFF
--- a/ethon.gemspec
+++ b/ethon.gemspec
@@ -20,7 +20,10 @@ Gem::Specification.new do |s|
 
   s.add_dependency('ffi', ['>= 1.15.0'])
 
-  s.files        = `git ls-files`.split("\n")
-  s.test_files   = `git ls-files -- spec/*`.split("\n")
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").reject do |file|
+      file.start_with?(*%w[. Gemfile Guardfile Rakefile profile spec])
+    end
+  end
   s.require_path = 'lib'
 end


### PR DESCRIPTION
There are several files in the gem package that aren't useful for downstream projects. Removing these files reduces the gem package size from **59K** to **39K**!

<details><summary>gem contents diff</summary>

```diff

< .github/workflows/ruby.yml
< .gitignore
< .rspec
  CHANGELOG.md
< Gemfile
< Guardfile
  LICENSE
  README.md
< Rakefile
  ethon.gemspec
  lib/ethon.rb
  lib/ethon/curl.rb
  lib/ethon/curls/classes.rb
  lib/ethon/curls/codes.rb
  lib/ethon/curls/constants.rb
  lib/ethon/curls/form_options.rb
  lib/ethon/curls/functions.rb
  lib/ethon/curls/infos.rb
  lib/ethon/curls/messages.rb
  lib/ethon/curls/options.rb
  lib/ethon/curls/settings.rb
  lib/ethon/easy.rb
  lib/ethon/easy/callbacks.rb
  lib/ethon/easy/debug_info.rb
  lib/ethon/easy/features.rb
  lib/ethon/easy/form.rb
  lib/ethon/easy/header.rb
  lib/ethon/easy/http.rb
  lib/ethon/easy/http/actionable.rb
  lib/ethon/easy/http/custom.rb
  lib/ethon/easy/http/delete.rb
  lib/ethon/easy/http/get.rb
  lib/ethon/easy/http/head.rb
  lib/ethon/easy/http/options.rb
  lib/ethon/easy/http/patch.rb
  lib/ethon/easy/http/post.rb
  lib/ethon/easy/http/postable.rb
  lib/ethon/easy/http/put.rb
  lib/ethon/easy/http/putable.rb
  lib/ethon/easy/informations.rb
  lib/ethon/easy/mirror.rb
  lib/ethon/easy/operations.rb
  lib/ethon/easy/options.rb
  lib/ethon/easy/params.rb
  lib/ethon/easy/queryable.rb
  lib/ethon/easy/response_callbacks.rb
  lib/ethon/easy/util.rb
  lib/ethon/errors.rb
  lib/ethon/errors/ethon_error.rb
  lib/ethon/errors/global_init.rb
  lib/ethon/errors/invalid_option.rb
  lib/ethon/errors/invalid_value.rb
  lib/ethon/errors/multi_add.rb
  lib/ethon/errors/multi_fdset.rb
  lib/ethon/errors/multi_remove.rb
  lib/ethon/errors/multi_timeout.rb
  lib/ethon/errors/select.rb
  lib/ethon/libc.rb
  lib/ethon/loggable.rb
  lib/ethon/multi.rb
  lib/ethon/multi/operations.rb
  lib/ethon/multi/options.rb
  lib/ethon/multi/stack.rb
  lib/ethon/version.rb
< profile/benchmarks.rb
< profile/memory_leaks.rb
< profile/perf_spec_helper.rb
< profile/support/memory_test_helpers.rb
< profile/support/os_memory_leak_tracker.rb
< profile/support/ruby_object_leak_tracker.rb
< spec/ethon/curl_spec.rb
< spec/ethon/easy/callbacks_spec.rb
< spec/ethon/easy/debug_info_spec.rb
< spec/ethon/easy/features_spec.rb
< spec/ethon/easy/form_spec.rb
< spec/ethon/easy/header_spec.rb
< spec/ethon/easy/http/custom_spec.rb
< spec/ethon/easy/http/delete_spec.rb
< spec/ethon/easy/http/get_spec.rb
< spec/ethon/easy/http/head_spec.rb
< spec/ethon/easy/http/options_spec.rb
< spec/ethon/easy/http/patch_spec.rb
< spec/ethon/easy/http/post_spec.rb
< spec/ethon/easy/http/put_spec.rb
< spec/ethon/easy/http_spec.rb
< spec/ethon/easy/informations_spec.rb
< spec/ethon/easy/mirror_spec.rb
< spec/ethon/easy/operations_spec.rb
< spec/ethon/easy/options_spec.rb
< spec/ethon/easy/queryable_spec.rb
< spec/ethon/easy/response_callbacks_spec.rb
< spec/ethon/easy/util_spec.rb
< spec/ethon/easy_spec.rb
< spec/ethon/libc_spec.rb
< spec/ethon/loggable_spec.rb
< spec/ethon/multi/operations_spec.rb
< spec/ethon/multi/options_spec.rb
< spec/ethon/multi/stack_spec.rb
< spec/ethon/multi_spec.rb
< spec/spec_helper.rb
< spec/support/localhost_server.rb
< spec/support/server.rb
```

</details>