### PR TITLE
CI: add Ruby 3.1 and 3.2 to the test matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,7 +23,7 @@ jobs:
         ruby-version: [2.5, 2.6, 2.7, '3.0', 3.1, 3.2, head, debug, truffleruby]
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install libcurl header
       run: |
         if ${{ matrix.os == 'macos' }}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        ruby-version: [2.5, 2.6, 2.7, 3.0, head, debug, truffleruby]
+        ruby-version: [2.5, 2.6, 2.7, '3.0', 3.1, 3.2, head, debug, truffleruby]
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Ruby 3.2 has [been released](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/)! Let's add it and Ruby 3.1 to the build matrix for confidence in compatibility.