### PR TITLE
Allow curl native libs to be configurable via ENV

### DIFF
--- a/lib/ethon/curls/settings.rb
+++ b/lib/ethon/curls/settings.rb
@@ -7,6 +7,6 @@ module Ethon
     callback :debug_callback, [:pointer, :debug_info_type, :pointer, :size_t, :pointer], :int
     callback :progress_callback, [:pointer, :long_long, :long_long, :long_long, :long_long], :int
     ffi_lib_flags :now, :global
-    ffi_lib ['libcurl', 'libcurl.so.4']
+    ffi_lib ['libcurl-impersonate-chrome', 'libcurl-impersonate-chrome.so.4']
   end
 end

--- a/lib/ethon/curls/settings.rb
+++ b/lib/ethon/curls/settings.rb
@@ -7,6 +7,6 @@ module Ethon
     callback :debug_callback, [:pointer, :debug_info_type, :pointer, :size_t, :pointer], :int
     callback :progress_callback, [:pointer, :long_long, :long_long, :long_long, :long_long], :int
     ffi_lib_flags :now, :global
-    ffi_lib ['libcurl-impersonate-chrome', 'libcurl-impersonate-chrome.so.4']
+    ffi_lib ENV.fetch('ETHON_CURL_LIBS', 'libcurl,libcurl.so.4').split(',')
   end
 end


### PR DESCRIPTION
We are using custom curl libs from [CURL Impersonate](https://github.com/lwthiker/curl-impersonate) with `ethon+typhoes+faraday` combo. Will be nice if those can be configurable via ENV vs hardcoding.

E.g.:
```sh
ETHON_CURL_LIBS=libcurl-impersonate-chrome,libcurl-impersonate-chrome.so.4 rails c
```