### PR TITLE
Use `Rackup::Handler.default` for Rack 3 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ group :development, :test do
 
   gem "sinatra"
 
+  gem "rackup"
+
   if Gem.ruby_version < Gem::Version.new("2.0.0")
     gem "json", "< 2"
   else

--- a/spec/support/localhost_server.rb
+++ b/spec/support/localhost_server.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'rack'
-require 'rack/handler/webrick'
 require 'net/http'
 
 # The code for this is inspired by Capybara's server:
@@ -41,10 +40,10 @@ class LocalhostServer
   end
 
   def boot
-    # Use WEBrick since it's part of the ruby standard library and is available on all ruby interpreters.
     options = { :Port => port }
-    options.merge!(:AccessLog => [], :Logger => WEBrick::BasicLog.new(StringIO.new)) unless ENV['VERBOSE_SERVER']
-    Rack::Handler::WEBrick.run(Identify.new(@rack_app), **options)
+    options.merge!(:AccessLog => [], :Logger => Rack::NullLogger.new(@rack_app)) unless ENV['VERBOSE_SERVER']
+    # This allows to use whatever web server is available. The Gemfile currently specifies WEBrick.
+    Rackup::Handler.default.run(Identify.new(@rack_app), **options)
   end
 
   def booted?
@@ -59,7 +58,7 @@ class LocalhostServer
   def concurrently
     if should_use_subprocess?
       pid = Process.fork do
-        trap(:INT) { ::Rack::Handler::WEBrick.shutdown }
+        trap(:INT) { ::Rackup::Handler.default.shutdown }
         yield
         exit # manually exit; otherwise this sub-process will re-run the specs that haven't run yet.
       end

--- a/spec/support/server.rb
+++ b/spec/support/server.rb
@@ -5,6 +5,8 @@ require 'zlib'
 require 'sinatra/base'
 
 TESTSERVER = Sinatra.new do
+  use Rack::RewindableInput::Middleware
+
   set :logging, nil
 
   fail_count = 0
@@ -94,7 +96,7 @@ TESTSERVER = Sinatra.new do
   end
 
   post '/**' do
-    request.env.merge!(:body => request.body.read).to_json
+    request.env.merge!(:body => request.body.tap {|b| b.rewind }.read).to_json
   end
 
   delete '/**' do
@@ -110,6 +112,6 @@ TESTSERVER = Sinatra.new do
   end
 
   route 'PURGE', '/**' do
-    request.env.merge!(:body => request.body.read).to_json
+    request.env.merge!(:body => request.body.tap {|b| b.rewind }.read).to_json
   end
 end


### PR DESCRIPTION
`Rack::Handler::WEBrick` was extracted from Rack to Rackup. Use this as an opportunity to move from WEBrick specific handler to generic `Rackup::Handler`. This eventually allows to specify server by `RACKUP_HANDLER` environment variable. ATM, Gemfile still specifies WEBrick.

This is related to #243 and allows to used e.g. Puma for experimenting