### PR TITLE
Use generic `Rackup::Handler.default`

### DIFF
--- a/spec/support/localhost_server.rb
+++ b/spec/support/localhost_server.rb
@@ -40,10 +40,10 @@ class LocalhostServer
   end
 
   def boot
-    # Use WEBrick since it's part of the ruby standard library and is available on all ruby interpreters.
     options = { :Port => port }
-    options.merge!(:AccessLog => [], :Logger => WEBrick::BasicLog.new(StringIO.new)) unless ENV['VERBOSE_SERVER']
-    Rackup::Handler::WEBrick.run(Identify.new(@rack_app), **options)
+    options.merge!(:AccessLog => [], :Logger => Rack::NullLogger.new(@rack_app)) unless ENV['VERBOSE_SERVER']
+    # This allows to use whatever web server is available. The Gemfile currently specifies WEBrick.
+    Rackup::Handler.default.run(Identify.new(@rack_app), **options)
   end
 
   def booted?
@@ -58,7 +58,7 @@ class LocalhostServer
   def concurrently
     if should_use_subprocess?
       pid = Process.fork do
-        trap(:INT) { ::Rack::Handler::WEBrick.shutdown }
+        trap(:INT) { ::Rackup::Handler.default.shutdown }
         yield
         exit # manually exit; otherwise this sub-process will re-run the specs that haven't run yet.
       end


### PR DESCRIPTION
Move from specific `Rack::Handler::WEBrick` to more generic `Rackup::Handler.default`. This chooses the best available handler automatically. If more handlers are available, `RACKUP_HANDLER` environment variable could be used to override the default.

ATM, Gemfile still specifies WEBrick, so this is the one which will be used. But replacing WEBrick by Puma should be as easy as updating the `Gemfile`

This is followup to #244 and this idea comes from [this](https://github.com/sinatra/sinatra/issues/2112#issuecomment-2985243203) discussion