### PR TITLE
Skip a test due to libcurl 8.7.x bug in CURLINFO_REQUEST_SIZE

### DIFF
--- a/spec/ethon/easy/informations_spec.rb
+++ b/spec/ethon/easy/informations_spec.rb
@@ -88,8 +88,15 @@ describe Ethon::Easy::Informations do
   end
 
   describe "#request_size" do
-    it "returns 53" do
-      expect(easy.request_size).to eq(53)
+    libcurl_version = Ethon::Curl.version_info[:version]
+    if libcurl_version.start_with?('8.7.')
+      it 'skips request_size on libcurl 8.7.x due to upstream bug' do
+        skip 'libcurl 8.7.x returns 0 due to curl bug #13269'
+      end
+    else
+      it 'returns 53' do
+        expect(easy.request_size).to eq(53)
+      end
     end
   end
 


### PR DESCRIPTION
This pr modifies the request_size test so that we skip it on versions of libcurl affected by a bug in CURLINFO_REQUEST_SIZE (https://github.com/curl/curl/issues/13269). The bug was fixed in 8.8.0 (https://curl.se/ch/8.8.0.html).

Unfortunately, the macos runner for our gh actions uses ones of the affected versions. Since this is an issue with libcurl itself, I think its fine to skip the test on the affected versions. I've also ran our tests against the surrounding versions to ensure this was the issue:

> Test run summary by libcurl version
>   • 8.5.0: 578 examples, 0 failures, 2 pending
>   • 8.6.0: 578 examples, 0 failures, 2 pending
>   • 8.7.0: 578 examples, 1 failure, 2 pending (request_size returned 0)
>   • 8.7.1: 578 examples, 1 failure, 2 pending (request_size returned 0)
>   • 8.8.0: 578 examples, 0 failures, 2 pending
>   • 8.9.0: 578 examples, 0 failures, 2 pending