### PR TITLE
Drop shebang from test server

### DIFF
--- a/spec/support/server.rb
+++ b/spec/support/server.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 require 'json'
 require 'zlib'


### PR DESCRIPTION
The `spec/support/server.rb` file does not have executable bit set, therefore the shebang is useless. Other option could be to add the executable bit and store it in repo.

And of course, the last option could be that setting the executable bit explicitly when needed is the right way to go. In that case, please feel free to ignore this PR and sorry for the noise.