### PR TITLE
Opt-in for MFA requirement explicitly

### DIFF
--- a/ethon.gemspec
+++ b/ethon.gemspec
@@ -26,4 +26,12 @@ Gem::Specification.new do |s|
     end
   end
   s.require_path = 'lib'
+
+  s.metadata              = {
+    'bug_tracker_uri'       => 'https://github.com/typhoeus/ethon/issues',
+    'changelog_uri'         => "https://github.com/typhoeus/ethon/blob/v#{s.version}/CHANGELOG.md",
+    'documentation_uri'     => "https://www.rubydoc.info/gems/ethon/#{s.version}",
+    'rubygems_mfa_required' => 'true',
+    'source_code_uri'       => "https://github.com/typhoeus/ethon/tree/v#{s.version}"
+  }
 end


### PR DESCRIPTION
As a popular gem (over 180 million total downloads), `ethon` implicitly requires that all privileged operations by any of the owners require OTP.

By explicitly setting `rubygems_mfa_required` metadata, the gem will show "NEW VERSIONS REQUIRE MFA" and "VERSION PUBLISHED WITH MFA" in the sidebar at https://rubygems.org/gems/ethon

This commit also introduces additional metadata

Ref:
- https://blog.rubygems.org/2022/08/15/requiring-mfa-on-popular-gems.html
- https://guides.rubygems.org/mfa-requirement-opt-in/

---

metadata verified via

```
$ gem build
$ gem spec -l ethon-0.17.0.gem 

# ...
metadata:
  bug_tracker_uri: https://github.com/typhoeus/ethon/issues
  changelog_uri: https://github.com/typhoeus/ethon/blob/v0.17.0/CHANGELOG.md
  documentation_uri: https://www.rubydoc.info/gems/ethon/0.17.0
  rubygems_mfa_required: 'true'
  source_code_uri: https://github.com/typhoeus/ethon/tree/v0.17.0
# ...
```
