### PR TITLE
Remove redundant encoding and require_relative check

### DIFF
--- a/ethon.gemspec
+++ b/ethon.gemspec
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 lib = File.expand_path('../lib/', __FILE__)
 $:.unshift lib unless $:.include?(lib)

--- a/lib/ethon/loggable.rb
+++ b/lib/ethon/loggable.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 module Ethon
 

--- a/profile/benchmarks.rb
+++ b/profile/benchmarks.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 require 'ethon'
 require 'open-uri'

--- a/spec/ethon/easy/queryable_spec.rb
+++ b/spec/ethon/easy/queryable_spec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 require 'spec_helper'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,13 +7,8 @@ Bundler.setup
 require "ethon"
 require 'rspec'
 
-if defined? require_relative
-  require_relative 'support/localhost_server'
-  require_relative 'support/server'
-else
-  require 'support/localhost_server'
-  require 'support/server'
-end
+require_relative 'support/localhost_server'
+require_relative 'support/server'
 
 # Ethon.logger = Logger.new($stdout).tap do |log|
 #   log.level = Logger::DEBUG


### PR DESCRIPTION
This magic comment is not needed anymore because the default encoding of source code files assumed by Ruby 2 is utf-8, and the minimum required Ruby version is 2.6

Auto-fixed via:

```
rubocop -a --only Style/Encoding
```

---

`require_relative` has been introduced in Ruby 1.9.2 and is available in all supported Ruby versions