### PR TITLE
Add `logger` to runtime dependencies

### DIFF
--- a/ethon.gemspec
+++ b/ethon.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_dependency('ffi', ['>= 1.15.0'])
+  s.add_dependency('logger')
 
   s.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").reject do |file|


### PR DESCRIPTION
Starting from Ruby 3.5, `logger` will no longer be part of the bundled gems.

How to replicate:
```
$ ruby --version
ruby 3.5.0dev (2025-06-15T04:41:29Z master c88c2319a8) +PRISM [arm64-darwin24]

$ ruby -e "require_relative 'lib/ethon'"
/path/to/ruby/did_you_mean/core_ext/name_error.rb:11: warning: logger is not part of the default gems since Ruby 3.5.0. Install logger from RubyGems.
<internal:/path/to/ruby/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require': cannot load such file -- logger (LoadError)
```

Close #242