### PR TITLE
Fix `on_headers` callbacks being called early

### DIFF
--- a/lib/ethon/easy/callbacks.rb
+++ b/lib/ethon/easy/callbacks.rb
@@ -52,9 +52,8 @@ module Ethon
       # @return [ Proc ] The callback.
       def header_write_callback
         @header_write_callback ||= proc {|stream, size, num, object|
-          result = headers
           @response_headers << stream.read_string(size * num)
-          result != :abort ? size * num : -1
+          size * num
         }
       end
 

--- a/lib/ethon/easy/callbacks.rb
+++ b/lib/ethon/easy/callbacks.rb
@@ -37,10 +37,10 @@ module Ethon
       # @return [ Proc ] The callback.
       def body_write_callback
         @body_write_callback ||= proc do |stream, size, num, object|
-          headers
+          headers_user_callback_result = headers
           result = body(chunk = stream.read_string(size * num))
           @response_body << chunk if result == :unyielded
-          result != :abort ? size * num : -1
+          (result != :abort && headers_user_callback_result != :abort) ? size * num : -1
         end
       end
 

--- a/spec/ethon/easy/callbacks_spec.rb
+++ b/spec/ethon/easy/callbacks_spec.rb
@@ -71,10 +71,12 @@ describe Ethon::Easy::Callbacks do
         easy.on_headers.clear
         easy.on_headers { :abort }
       end
-      let(:header_write_callback) { easy.instance_variable_get(:@header_write_callback) }
-
+      let(:body_write_callback) { easy.instance_variable_get(:@body_write_callback) }
+      # on_headers callbacks are expected to be called exactly one time, once all headers are in.
+      # We can't abort exactly on receiving the headers, as we might need to follow redirects,
+      # so we do the next best thing, which is aborting on the first body chunk.
       it "returns -1 to indicate abort to libcurl" do
-        expect(header_write_callback.call(stream, 1, 1, nil)).to eq(-1)
+        expect(body_write_callback.call(stream, 1, 1, nil)).to eq(-1)
       end
     end
   end

--- a/spec/ethon/easy/http_spec.rb
+++ b/spec/ethon/easy/http_spec.rb
@@ -45,7 +45,7 @@ describe Ethon::Easy::Http do
 
           it "notifies when headers are ready" do
             headers = []
-            easy.on_headers { |r| headers << r.response_headers }
+            easy.on_headers { |r| headers << r.response_headers.dup }
             easy.http_request(url, action, options)
             easy.perform
             expect(headers).to eq([easy.response_headers])


### PR DESCRIPTION
### Context
PR #221 introduced the ability to abort a request from  the `on_headers` user defined callbacks.
Before this PR , `on_headers` callbacks were called exactly one time and only once all headers are in, including from multiple redirects. This is the expected value for `response_headers` inside a `on_headers` callback for a request that followed a redirect:
```
HTTP/1.1 302 Found
Location: http://localhost:3001/
Content-Type: text/html;charset=utf-8
Content-Length: 0
X-Xss-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
Server: WEBrick/1.9.1 (Ruby/3.4.5/2025-07-16)
Date: Wed, 27 Aug 2025 13:31:38 GMT
Connection: Keep-Alive

HTTP/1.1 200 OK
Content-Type: text/html;charset=utf-8
Content-Length: 653
X-Xss-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
Server: WEBrick/1.9.1 (Ruby/3.4.5/2025-07-16)
Date: Wed, 27 Aug 2025 13:31:38 GMT
Connection: Keep-Alive
```
Since we wanted all headers to be available to the callback, `on_headers` was actually called when the body write function started receiving data - and from the complete callback to handle requests without a body. This approach was endorsed by libcurl's author in response to a question about detecting the end of headers [0].

### Problem
PR #221 moved the execution of `on_headers` to the actual header write function. I think this was done to allow aborting early, before starting to download the body and before following redirects. The problem is that libcurl calls the header write function once **per header line**, so when the user code in `on_headers` runs, `response_headers` contains only the status line (ex: `HTTP/1.1 200 OK`).
Since Typhoeus trims out the status line, when the callback ran, the headers were empty (#229, https://github.com/typhoeus/typhoeus/issues/705, https://github.com/typhoeus/typhoeus/issues/710).

Additionally, when following redirects, the change made so the callback was called immediately on the first line of headers received from the initial request, which is not the expected behavior (#231).

### Solution
This PR reverts the change in #221 that made `on_headers` be called before receiving all headers, and keeps support for aborting from the callback by checking it's return value in the body write function.

### Testing
We had a test that should have caught the unintended change in #221, but the test itself had a bug (fixed in https://github.com/typhoeus/ethon/commit/a7af5c2143259bbe73472025b0e7023bccbca5df). I've also modified the test for returning `:abort` from `on_headers` so that it checks that the request gets cancelled from the body write function.

### Future improvements
We could offer a way for users to cancel an in-flight request right when they receive the header they need, which was the intention behind #221. This would require creating an new "raw" headers callback, to preserve the current expected `on_headers` behavior.


[0] https://curl.se/mail/lib-2009-02/0243.html