### PR TITLE
Replace broken ssl data with summary

### DIFF
--- a/lib/ethon/easy/callbacks.rb
+++ b/lib/ethon/easy/callbacks.rb
@@ -69,7 +69,14 @@ module Ethon
         @debug_callback ||= proc {|handle, type, data, size, udata|
           message = data.read_string(size)
           @debug_info.add type, message
-          print message unless [:data_in, :data_out].include?(type)
+
+          if [:ssl_data_in, :ssl_data_out].include?(type)
+            print "[#{size} bytes data]\n"
+          elsif [:data_in, :data_out].include?(type)
+            # print "} [#{size} bytes data]\n"
+          else
+            print message
+          end
           0
         }
       end


### PR DESCRIPTION
Our debug callback was attempting to print binary ssl data, causing issues with the terminal.
This PR replaces it with a summary containing the number of bytes transferred, inspired by the behavior of the curl cli.
Fixes https://github.com/typhoeus/typhoeus/issues/493
## Before
```
Making request to https://example.com with verbose=true
Host example.com:443 was resolved.
IPv6: 2600:1408:ec00:36::1736:7f31, 2600:1406:bc00:53::b81e:94ce, 2600:1406:5e00:6::17ce:bc1b, 2600:1406:5e00:6::17ce:bc12, 2600:1406:bc00:53::b81e:94c8, 2600:1408:ec00:36::173
6:7f24
IPv4: 23.220.75.232, 23.192.228.84, 23.220.75.245, 23.215.0.138, 23.215.0.136, 23.192.228.80
  Trying [2600:1408:ec00:36::1736:7f31]:443...
ALPN: curl offers h2,http/1.1
TLSv1.3 (OUT), TLS handshake, Client hello (1):
<���r>�e��a�b�ʘN�X�wd�%� F4�Io~��b�L5�t��aht^���<��,�0�̨̩̪�+�/��$�(k�#�'g
�9      ��3��=<5/��
                   example.com


64ttp/1.11

�����'x���.�8���c
�a�n7@�X�Yr�V���I� ؽ�Eq_�Lz�%\��F����=Ǭ�b�B�
&�Vb���
v�D~'(�,�k�r�"\,f��t|�����c["W�'����(׫�v����V�IUbu��J�5J�H#�ԫ_n�&�8 ����8�94��,y�u3BQ`��M�b�Y�����ļ||2�'�� :L��JF���(&��Qa�e>��+芭c4kR  U��'!��E��'�PM+@{n��k��14¦���+ֈd�P�
                                                                                                                                                                           �p>��
�T��i0bv�D�
           ���z��;��a�㖝:/�&EvHum�
�2L&t1���e�tA�|ku"���K
�ke�1���;��'@Kyf� 6k�L�es��-D,��(�X^z�k��U��ud�F�l�S;�ah������PJ���X
                                      ЍOڂ��Ĳ�P\i�
H�f     �3I��5�\#w�f
                    ��F��Nh٫I["�ad�),(Gl��39�r��x�۷d��/��r��4Ab�l���a�UF庅���d�(7`���#RR��[i!�Y�%
                                                                                                 �T iS%"�sH�{�
����ep�a�ë��0J�4pA�7JM��A�h[�Z��W�q-Xhhc̪�p�r���:X�3%�->�d0�:�̡*I�9�i�#�sZ1��a��2رΡ~0I���X�S��1w�0��@8��m�\�U��R��=�A�u~�I�[%�|.�w������A�Q^ /WK~{Δwz���S�$A
*�̉W\�8����XB�ۍ�w��q{��n��G�/|l]���&[!�ti�       �U�A�
6�}�0�>Kq�YB5xr��.�,��:U�wZ��b<Ǒ�Zm     ��GL�ȋ�7�q��S�x �=2��Z&d�C[�S�1�$�       ��������a�y���t�8����Ǔ�מ�&�    ���pm�x�c��k��3  �ZS�5E��ǈ<{eq�-a�ye" 2�: CAfile: /etc/ssl/certs
/ca-certificates.crt
 CApath: none
zTLSv1.3 (IN), TLS handshake, Server hello (2):
vL�sL�3?�~rP��,�B���wR
                      �S�j�� F4�Io~ˋ�b�L5�t��aht^���.+3$ ��D<uIKW��)��c�31u�j�/*�n+��j�TLSv1.3 (IN), TLS change cipher, Change cipher spec (1):
.TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):

h2      ?TLSv1.3 (IN), TLS handshake, Certificate (11):

        *       &�0��0�!�
ؓ��h���z@O쯚0
*�H�=0Y1
        0       UUS10U

260115235959Z0��1*DigiCert Global G3 TLS ECC SHA384 2020 CA10
                 0      UUS10U
California10U
             Los Angeles1<0:U
3Internet Corporation for Assigned Names and Numbers10U
*.example.com�Y0*�H�*�H�=B�H��-a�j��8������<^�ӄ(7�$�� qt���N    ;��fsϯΓ0��0U#0��#�k��7]�m!9v��gި0U��j2
              example.com0>U 70503g�
                                    0)0+ttp://www.digicert.com/CPS0U��0U%+0��U��0��0H�F�D�Bhttp://crl3.digicert.com/DigiCertGlobalG3TLSECCSHA3842020CA1-2.crl0H�F�D�Bhttp://crl4
.digicert.com/DigiCertGlobalG3TLSECCSHA3842020CA1-2.crl0�+{0y0+0�http://ocsp.digicert.com0+0�Ehttp://cacerts.digicert.com/DigiCertGlobalG3TLSECCSHA3842020CA1-2.crt0
                                                                                                                                                                    U�00�{
+�y�k�getW���>3q2%�!�%�a�N!�gz�E0C$ZL|�);�����5���َGdWsۯ�S� RۮQ��!>T5b_|Q�}mPh�d4Ү�4��U�ud�l�짉�.��O(5'�����}��gz�F0D p���]P�'���"0a��!��/:ؕ� r0S/���&��+
                                                                                                                                                       e^u�)��Q�[       rvI��i�|
��6�͇d��[�
ч��UR���)��ÔgzG0E hXz�!��\ �u��}�Z1�6og�8�AV&�Ul!�ʣ\6, F�(tK��7s��k�8�(�X��<�0
*�H�=h0e1�FS�o�X��

                  �0
*�H�=0a1
        0       UUS10U

DigiCert Inc10U
310413235959Z0Y1ww.digicert.com1 0UDigiCert Global Root G30
                0       UUS10U

DigiCert Inc1301U*DigiCert Global G3 TLS ECC SHA384 2020 CA10v0*�H�=+�"bx��u��]c��]��I֯�YcC#��He0�J4��>��W(H�
                                                                                                            ���Ӗ��Eҋ�KC�s�msH4�F        εVT�_z��ll��
                                                                                                                                                    �&V.��g���0�~0U0�0U�#�k��7]�
m!9v��gި0U#0���H���خ6Acib)�K�0U�̆0U%+0+j0h0+0�http://ocsp.digicert.com0+0�4http://cacerts.digicert.com/DigiCertGlobalRootG3.crt0BU;0907�5�3�1http://crl3.digicert.com/DigiCertGlob
alRootG3.crl0=U 6040
                        `�H��l0g�
                                 g�
                                   g�
                                     g�
                                       0
*�H�=h0e0~&Xn�
              �A�z���p�beO� �G�[�g1��rz�"r@Bne���K1�֮4�[?gǨox��1D�]Ƹx����2X��:�<�o����3�`TLSv1.3 (IN), TLS handshake, CERT verify (15):
KG0E!���Nb?X�m�_3�r2_�@Mvs���-��� &��\���2oi����q�\����稒�q�^�QETLSv1.3 (IN), TLS handshake, Finished (20):
0ڎ3g��"��!�csnk����Z)�)g�V_��#����7:���R�:*TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
ETLSv1.3 (OUT), TLS handshake, Finished (20):
0�W��a�+�-.A��N�Ui��x2��cu���5?��7�1h;
                                      ��mSSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384 / x25519 / id-ecPublicKey
ALPN: server accepted h2
Server certificate:
 subject: C=US; ST=California; L=Los Angeles; O=Internet Corporation for Assigned Names and Numbers; CN=*.example.com
 start date: Jan 15 00:00:00 2025 GMT
 expire date: Jan 15 23:59:59 2026 GMT
 subjectAltName: host "example.com" matched cert's "example.com"
 issuer: C=US; O=DigiCert Inc; CN=DigiCert Global G3 TLS ECC SHA384 2020 CA1
 SSL certificate verify ok.
  Certificate level 0: Public key type EC/prime256v1 (256/128 Bits/secBits), signed using ecdsa-with-SHA384
  Certificate level 1: Public key type EC/secp384r1 (384/192 Bits/secBits), signed using ecdsa-with-SHA384
  Certificate level 2: Public key type EC/secp384r1 (384/192 Bits/secBits), signed using ecdsa-with-SHA384
Connected to example.com (2600:1408:ec00:36::1736:7f31) port 443
using HTTP/2
[HTTP/2] [1] OPENED stream for https://example.com/
[HTTP/2] [1] [:method: GET]
[HTTP/2] [1] [:scheme: https]
[HTTP/2] [1] [:authority: example.com]
[HTTP/2] [1] [:path: /]
[HTTP/2] [1] [accept: */*]
lGET / HTTP/2
Host: example.com
Accept: */*

Request completely sent off
*TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
����;�Y���?t�ؒ�5�G��'�_�nHw ��߂D���.,)�DL�5�H���NCwޥ�9��)�ݽ�e�9�.��
�����z�
       ��&      @��v]�kT��>�]�K|�4�P�\Ę�j��:�ѵ����N�۳MU��z26���Ͻ�ᒾ����l1zt�`��~˃3�����f]=�^;�����QX� Er��D֨�S�'Zf,q�Й�Y.d*TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
����;�Y���?tBʌA�V��� �\Q�       ���0Q���ƽ�*�5
�p*�p`�W�<�Y�E}~�.�M2���\l��*y^74Tس���o�`U��K���ܟ��6=W��{8�HTTP/2 200 �>�6b�>P�o�:�xDl�/���Kk@���L���Y�Ǩ�n���:�0Z���~
content-type: text/html
etag: "84238dfc8092e5d9c0dac8ef93371a07:1736799080.121134"
last-modified: Mon, 13 Jan 2025 20:11:20 GMT
cache-control: max-age=2939
date: Wed, 27 Aug 2025 22:44:13 GMT
alt-svc: h3=":443"; ma=93600,h3-29=":443"; ma=93600
content-length: 1256

Connection #0 to host example.com left intact
```

## After
```
Making request to https://example.com with verbose=true
Host example.com:443 was resolved.
IPv6: 2600:1406:5e00:6::17ce:bc12, 2600:1406:5e00:6::17ce:bc1b, 2600:1406:bc00:53::b81e:94ce, 2600:1408:ec00:36::1736:7f24, 2600:1406:bc00:53::b81e:94c8, 2600:1408:ec00:36::173
6:7f31
IPv4: 23.220.75.245, 23.192.228.84, 23.220.75.232, 23.215.0.138, 23.215.0.136, 23.192.228.80
  Trying [2600:1406:5e00:6::17ce:bc12]:443...
ALPN: curl offers h2,http/1.1
[5 bytes data]
TLSv1.3 (OUT), TLS handshake, Client hello (1):
[1557 bytes data]
 CAfile: /etc/ssl/certs/ca-certificates.crt
 CApath: none
[5 bytes data]
TLSv1.3 (IN), TLS handshake, Server hello (2):
[122 bytes data]
[5 bytes data]
TLSv1.3 (IN), TLS change cipher, Change cipher spec (1):
[1 bytes data]
[5 bytes data]
[1 bytes data]
TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
[29 bytes data]
[5 bytes data]
[1 bytes data]
TLSv1.3 (IN), TLS handshake, Certificate (11):
[2350 bytes data]
[5 bytes data]
[1 bytes data]
TLSv1.3 (IN), TLS handshake, CERT verify (15):
[80 bytes data]
[5 bytes data]
[1 bytes data]
TLSv1.3 (IN), TLS handshake, Finished (20):
[52 bytes data]
[5 bytes data]
TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
[1 bytes data]
[5 bytes data]
[1 bytes data]
TLSv1.3 (OUT), TLS handshake, Finished (20):
[52 bytes data]
SSL connection using TLSv1.3 / TLS_AES_256_GCM_SHA384 / x25519 / id-ecPublicKey
ALPN: server accepted h2
Server certificate:
 subject: C=US; ST=California; L=Los Angeles; O=Internet Corporation for Assigned Names and Numbers; CN=*.example.com
 start date: Jan 15 00:00:00 2025 GMT
 expire date: Jan 15 23:59:59 2026 GMT
 subjectAltName: host "example.com" matched cert's "example.com"
 issuer: C=US; O=DigiCert Inc; CN=DigiCert Global G3 TLS ECC SHA384 2020 CA1
 SSL certificate verify ok.
  Certificate level 0: Public key type EC/prime256v1 (256/128 Bits/secBits), signed using ecdsa-with-SHA384
  Certificate level 1: Public key type EC/secp384r1 (384/192 Bits/secBits), signed using ecdsa-with-SHA384
  Certificate level 2: Public key type EC/secp384r1 (384/192 Bits/secBits), signed using ecdsa-with-SHA384
Connected to example.com (2600:1406:5e00:6::17ce:bc12) port 443
using HTTP/2
[HTTP/2] [1] OPENED stream for https://example.com/
[HTTP/2] [1] [:method: GET]
[HTTP/2] [1] [:scheme: https]
[HTTP/2] [1] [:authority: example.com]
[HTTP/2] [1] [:path: /]
[HTTP/2] [1] [accept: */*]
[5 bytes data]
[1 bytes data]
GET / HTTP/2
Host: example.com
Accept: */*

Request completely sent off
[5 bytes data]
[1 bytes data]
TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
[281 bytes data]
[5 bytes data]
[1 bytes data]
TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
[265 bytes data]
[5 bytes data]
[1 bytes data]
[5 bytes data]
[1 bytes data]
[5 bytes data]
[1 bytes data]
[5 bytes data]
[1 bytes data]
HTTP/2 200 
content-type: text/html
etag: "84238dfc8092e5d9c0dac8ef93371a07:1736799080.121134"
last-modified: Mon, 13 Jan 2025 20:11:20 GMT
cache-control: max-age=2696
date: Wed, 27 Aug 2025 22:46:04 GMT
alt-svc: h3=":443"; ma=93600,h3-29=":443"; ma=93600
content-length: 1256

[5 bytes data]
[1 bytes data]
Connection #0 to host example.com left intact
```