### PR TITLE
Add Windows curl DLL names

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,19 +19,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, macos]
+        os: [ubuntu, macos, windows]
         ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', head, debug, truffleruby]
+        exclude:
+          - os: windows
+            ruby-version: debug
+          - os: windows
+            ruby-version: truffleruby
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:
     - uses: actions/checkout@v3
-    - name: Install libcurl header
+    - name: Install libcurl (Ubuntu)
+      if: matrix.os == 'ubuntu'
       run: |
-        if ${{ matrix.os == 'macos' }}
-        then
-          brew install curl
-        else
-          sudo apt update && sudo apt install -y --no-install-recommends libcurl4-openssl-dev
-        fi
+        sudo apt update && sudo apt install -y --no-install-recommends libcurl4-openssl-dev
+    - name: Install libcurl (macOS)
+      if: matrix.os == 'macos'
+      run: |
+        brew install curl
+    - name: Install libcurl (Windows)
+      if: matrix.os == 'windows'
+      run: |
+        ridk exec pacman -S --noconfirm mingw-w64-ucrt-x86_64-curl mingw-w64-x86_64-curl
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/lib/ethon/curls/settings.rb
+++ b/lib/ethon/curls/settings.rb
@@ -7,6 +7,6 @@ module Ethon
     callback :debug_callback, [:pointer, :debug_info_type, :pointer, :size_t, :pointer], :int
     callback :progress_callback, [:pointer, :long_long, :long_long, :long_long, :long_long], :int
     ffi_lib_flags :now, :global
-    ffi_lib ['libcurl', 'libcurl.so.4']
+    ffi_lib ['libcurl', 'libcurl.so.4', 'libcurl-4', 'libcurl-x64', 'libcurl-arm64']
   end
 end


### PR DESCRIPTION
Fixes #270

This PR resolves the `LoadError` on Windows by adding the missing DLL names to `ffi_lib`.

Currently, `ethon` only looks for `libcurl` and `libcurl.so.4`.
However, on modern Windows environments, the curl DLL is named differently depending on how it was installed:

1. MSYS2 (RubyInstaller default):
   * Installing via `pacman -S mingw-w64-ucrt-x86_64-curl` provides `libcurl-4.dll`.
2. Official curl for Windows:
   * Downloading the official binaries from curl.se provides architecture-specific names like `libcurl-x64.dll` and `libcurl-arm64.dll`.

